### PR TITLE
feat: supported Bootstrap script

### DIFF
--- a/FlashSpace/Settings/IntegrationsSettingsView.swift
+++ b/FlashSpace/Settings/IntegrationsSettingsView.swift
@@ -17,6 +17,12 @@ struct IntegrationsSettingsView: View {
             }
 
             Section(
+                header: Text("Run script on app launch:")
+            ) {
+                TextField("", text: $settings.runScriptOnLaunch)
+            }
+
+            Section(
                 header: Text("Run script on workspace change:"),
                 footer: Text(
                     """

--- a/FlashSpace/Utils/Integrations.swift
+++ b/FlashSpace/Utils/Integrations.swift
@@ -10,7 +10,7 @@ import Foundation
 enum Integrations {
     private static let settings = AppDependencies.shared.settingsRepository
 
-    static func runIfNeeded(workspace: Workspace) {
+    static func runOnActivateIfNeeded(workspace: Workspace) {
         let script = settings.runScriptOnWorkspaceChange.trimmingCharacters(in: .whitespaces)
 
         guard settings.enableIntegrations, !script.isEmpty else { return }
@@ -22,6 +22,17 @@ enum Integrations {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", scriptWithReplacements]
+        task.launch()
+    }
+
+    static func runOnAppLaunchIfNeeded() {
+        let script = settings.runScriptOnLaunch.trimmingCharacters(in: .whitespaces)
+      
+        guard settings.enableIntegrations, !script.isEmpty else { return }
+
+        let task = Process()
+        task.launchPath = "/bin/sh"
+        task.arguments = ["-c", script]
         task.launch()
     }
 }

--- a/FlashSpace/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Workspaces/WorkspaceManager.swift
@@ -44,7 +44,7 @@ final class WorkspaceManager {
         print("\n\nWORKSPACE: \(workspace.name)")
         print("----")
 
-        Integrations.runIfNeeded(workspace: workspace)
+        Integrations.runOnActivateIfNeeded(workspace: workspace)
 
         lastWorkspaceActivation = Date()
         activeWorkspace[workspace.display] = workspace


### PR DESCRIPTION
Added the feature to run specific scripts when the app is launched.

This is used to utilize tools like [JankyBorders](https://github.com/FelixKratz/JankyBorders).
I'm not aware of the current project structure roadmap, so I've utilized a lot of the existing structure for now, but please comment if it needs to be changed.

<img width="892" alt="image" src="https://github.com/user-attachments/assets/d873dd8b-6371-4ee7-8381-80d6188c2866" />