### PR TITLE
feat: added workspace symbol icon in menu bar

### DIFF
--- a/FlashSpace.xcodeproj/project.pbxproj
+++ b/FlashSpace.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		16999AE42D3DC77A0006EA91 /* ServiceManagement.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16999AE32D3DC77A0006EA91 /* ServiceManagement.framework */; };
 		2C5A21F7CFA65934F22ECA93 /* AXUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14242986FC549EA6F2EE11B8 /* AXUIElement.swift */; };
 		5C8832A1764AC1F6505BB8E4 /* Integrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01904D0D8EB8017AEF4CD453 /* Integrations.swift */; };
+		62A2C20E2D44463D00D8A19F /* SymbolPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 62A2C20D2D44463D00D8A19F /* SymbolPicker */; };
 		CA65DED962CD106A86C389C2 /* NSRunningApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2E1D011156B9FFF828F2E9 /* NSRunningApplication.swift */; };
 		DD48ACCA45929209284841E9 /* IntegrationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF62C0D4D9928BC04344735A /* IntegrationsSettingsView.swift */; };
 /* End PBXBuildFile section */
@@ -80,6 +81,7 @@
 			files = (
 				16999A192D3D978E0006EA91 /* ShortcutRecorder in Frameworks */,
 				16999AE42D3DC77A0006EA91 /* ServiceManagement.framework in Frameworks */,
+				62A2C20E2D44463D00D8A19F /* SymbolPicker in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,6 +235,7 @@
 			name = FlashSpace;
 			packageProductDependencies = (
 				16999A182D3D978E0006EA91 /* ShortcutRecorder */,
+				62A2C20D2D44463D00D8A19F /* SymbolPicker */,
 			);
 			productName = FlashSpace;
 			productReference = 16999A052D3D97770006EA91 /* FlashSpace-Dev.app */;
@@ -264,6 +267,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				16999A172D3D978E0006EA91 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */,
+				62A2C20C2D44463D00D8A19F /* XCRemoteSwiftPackageReference "SymbolPicker" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 16999A062D3D97770006EA91 /* Products */;
@@ -512,6 +516,14 @@
 				minimumVersion = 3.4.0;
 			};
 		};
+		62A2C20C2D44463D00D8A19F /* XCRemoteSwiftPackageReference "SymbolPicker" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/xnth97/SymbolPicker";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.6.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -519,6 +531,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 16999A172D3D978E0006EA91 /* XCRemoteSwiftPackageReference "ShortcutRecorder" */;
 			productName = ShortcutRecorder;
+		};
+		62A2C20D2D44463D00D8A19F /* SymbolPicker */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 62A2C20C2D44463D00D8A19F /* XCRemoteSwiftPackageReference "SymbolPicker" */;
+			productName = SymbolPicker;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/FlashSpace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FlashSpace.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0e384404867419f3da3da59ee70e4fe8e55017cf6e9a247995b86fe7358fdde7",
+  "originHash" : "6b559d400857b01f87fd2d75fba30d6489a9e604c38c7bee5aa79009883863e4",
   "pins" : [
     {
       "identity" : "shortcutrecorder",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "c86ce0f9be5353ba998966121c7631602a9a36f7",
         "version" : "3.4.0"
+      }
+    },
+    {
+      "identity" : "symbolpicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/xnth97/SymbolPicker",
+      "state" : {
+        "revision" : "da4136a37736de04df11f47ef096efe5557d066a",
+        "version" : "1.6.0"
       }
     }
   ],

--- a/FlashSpace/FlashSpaceApp.swift
+++ b/FlashSpace/FlashSpaceApp.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 @main
 struct FlashSpaceApp: App {
+    @StateObject
+    private var workspaceManager = AppDependencies.shared.workspaceManager
+
     @Environment(\.openWindow) private var openWindow
 
     var body: some Scene {
@@ -22,7 +25,7 @@ struct FlashSpaceApp: App {
         }
         .windowResizability(.contentSize)
 
-        MenuBarExtra("FlashSpace", systemImage: "bolt.fill") {
+        MenuBarExtra("FlashSpace", systemImage: workspaceManager.activeWorkspaceSymbolIconName ?? "bolt.fill") {
             Text("FlashSpace v\(AppConstants.version)")
 
             Button("Open") {

--- a/FlashSpace/MainView.swift
+++ b/FlashSpace/MainView.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import SwiftUI
+import SymbolPicker
 
 struct MainView: View {
     @Environment(\.openWindow) var openWindow
@@ -36,6 +37,9 @@ struct MainView: View {
                 userInput: $viewModel.userInput,
                 isPresented: $viewModel.isInputDialogPresented
             )
+        }
+        .sheet(isPresented: $viewModel.isSymbolPickerPresented) {
+            SymbolPicker(symbol: $viewModel.workspaceSymbolIconName)
         }
     }
 
@@ -109,6 +113,18 @@ struct MainView: View {
 
                 Text("Assign App Shortcut:")
                 HotKeyControl(shortcut: $viewModel.workspaceAssignShortcut).padding(.bottom)
+
+                Text("Menu Bar Icon:")
+                HStack {
+                    Button {
+                        viewModel.isSymbolPickerPresented = true
+                    } label: {
+                        Image(systemName: viewModel.workspaceSymbolIconName ?? "bolt.fill")
+                            .frame(maxWidth: .infinity)
+                    }
+                    Button("Reset", action: viewModel.resetWorkspaceSymbolIcon)
+                }
+                .padding(.bottom)
 
                 Button("Save", action: viewModel.updateWorkspace)
                     .disabled(viewModel.isSaveButtonDisabled)

--- a/FlashSpace/MainViewModel.swift
+++ b/FlashSpace/MainViewModel.swift
@@ -21,7 +21,9 @@ final class MainViewModel: ObservableObject {
     @Published var workspaceAssignShortcut: HotKeyShortcut?
     @Published var workspaceDisplay = ""
     @Published var workspaceAppToFocus: String?
+    @Published var workspaceSymbolIconName: String?
 
+    @Published var isSymbolPickerPresented = false
     @Published var isInputDialogPresented = false
     @Published var userInput = ""
     @Published var dismissOnLaunch = false
@@ -69,7 +71,8 @@ final class MainViewModel: ObservableObject {
             (
                 selectedWorkspace.appToFocus == workspaceAppToFocus ||
                     selectedWorkspace.appToFocus == nil && workspaceAppToFocus == workspaceApps?.last
-            )
+            ) &&
+            selectedWorkspace.symbolIconName == workspaceSymbolIconName
     }
 
     private var cancellables: Set<AnyCancellable> = []
@@ -113,6 +116,7 @@ final class MainViewModel: ObservableObject {
         workspaceDisplay = selectedWorkspace?.display ?? NSScreen.main?.localizedName ?? ""
         workspaceApps = selectedWorkspace?.apps
         workspaceAppToFocus = selectedWorkspace?.appToFocus ?? workspaceApps?.last
+        workspaceSymbolIconName = selectedWorkspace?.symbolIconName
         selectedApp = nil
     }
 
@@ -157,7 +161,8 @@ extension MainViewModel {
             activateShortcut: workspaceShortcut,
             assignAppShortcut: workspaceAssignShortcut,
             apps: selectedWorkspace.apps,
-            appToFocus: workspaceAppToFocus
+            appToFocus: workspaceAppToFocus,
+            symbolIconName: workspaceSymbolIconName
         )
 
         workspaceRepository.updateWorkspace(updatedWorkspace)
@@ -200,5 +205,9 @@ extension MainViewModel {
         workspaces = workspaceRepository.workspaces
         self.selectedApp = nil
         self.selectedWorkspace = workspaces.first { $0.id == selectedWorkspace.id }
+    }
+
+    func resetWorkspaceSymbolIcon() {
+        workspaceSymbolIconName = nil
     }
 }

--- a/FlashSpace/Workspaces/Workspace.swift
+++ b/FlashSpace/Workspaces/Workspace.swift
@@ -18,6 +18,7 @@ struct Workspace: Identifiable, Codable, Hashable {
         case assignAppShortcut
         case apps
         case appToFocus
+        case symbolIconName
     }
 
     let id: WorkspaceID
@@ -27,4 +28,5 @@ struct Workspace: Identifiable, Codable, Hashable {
     var assignAppShortcut: HotKeyShortcut?
     var apps: [String]
     var appToFocus: String?
+    var symbolIconName: String?
 }

--- a/FlashSpace/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Workspaces/WorkspaceManager.swift
@@ -11,7 +11,10 @@ import ShortcutRecorder
 
 typealias DisplayName = String
 
-final class WorkspaceManager {
+final class WorkspaceManager: ObservableObject {
+    @Published
+    private(set) var activeWorkspaceSymbolIconName: String?
+
     private(set) var activeWorkspace: [DisplayName: Workspace] = [:]
     private(set) var lastWorkspaceActivation = Date.distantPast
 
@@ -59,6 +62,7 @@ final class WorkspaceManager {
 
         lastWorkspaceActivation = Date()
         activeWorkspace[workspace.display] = workspace
+        activeWorkspaceSymbolIconName = workspace.symbolIconName
         showApps(in: workspace, setFocus: setFocus)
         hideApps(in: workspace)
 


### PR DESCRIPTION
Added visualization customization for people using the Native Menu bar.

The [SymbolPicker](https://github.com/xnth97/SymbolPicker) package has been added for this purpose.
If you don't want this, you can let them type the symbolName directly, although it's not very user-friendly.


https://github.com/user-attachments/assets/4a94e8a8-eba4-44d0-b289-c274c3d5352b

