### PR TITLE
feat: added shortcut to switch to the recent workspace

### DIFF
--- a/FlashSpace/Settings/SettingsRepository.swift
+++ b/FlashSpace/Settings/SettingsRepository.swift
@@ -24,6 +24,7 @@ struct AppSettings: Codable {
     var centerCursorOnWorkspaceChange: Bool?
     var switchToPreviousWorkspace: HotKeyShortcut?
     var switchToNextWorkspace: HotKeyShortcut?
+    var switchToRecentWorkspace: HotKeyShortcut?
     var unassignFocusedApp: HotKeyShortcut?
 
     var enableIntegrations: Bool?
@@ -92,6 +93,10 @@ final class SettingsRepository: ObservableObject {
         didSet { updateSettings() }
     }
 
+    @Published var switchToRecentWorkspace: HotKeyShortcut? {
+        didSet { updateSettings() }
+    }
+
     @Published var unassignFocusedApp: HotKeyShortcut? {
         didSet { updateSettings() }
     }
@@ -154,6 +159,7 @@ final class SettingsRepository: ObservableObject {
             centerCursorOnWorkspaceChange: centerCursorOnWorkspaceChange,
             switchToPreviousWorkspace: switchToPreviousWorkspace,
             switchToNextWorkspace: switchToNextWorkspace,
+            switchToRecentWorkspace: switchToRecentWorkspace,
             unassignFocusedApp: unassignFocusedApp,
 
             enableIntegrations: enableIntegrations,
@@ -194,6 +200,7 @@ final class SettingsRepository: ObservableObject {
         centerCursorOnWorkspaceChange = settings.centerCursorOnWorkspaceChange ?? false
         switchToPreviousWorkspace = settings.switchToPreviousWorkspace
         switchToNextWorkspace = settings.switchToNextWorkspace
+        switchToRecentWorkspace = settings.switchToRecentWorkspace
         unassignFocusedApp = settings.unassignFocusedApp
 
         enableIntegrations = settings.enableIntegrations ?? false

--- a/FlashSpace/Settings/WorkspacesSettingsView.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsView.swift
@@ -21,6 +21,7 @@ struct WorkspacesSettingsView: View {
             }
 
             Section {
+                hotkey("Recent Workspace", for: $settings.switchToRecentWorkspace)
                 hotkey("Previous Workspace", for: $settings.switchToPreviousWorkspace)
                 hotkey("Next Workspace", for: $settings.switchToNextWorkspace)
                 Text(

--- a/FlashSpace/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Workspaces/WorkspaceManager.swift
@@ -88,7 +88,12 @@ extension WorkspaceManager {
         Integrations.runOnActivateIfNeeded(workspace: workspace)
 
         lastWorkspaceActivation = Date()
-        mostRecentWorkspace[workspace.display] = activeWorkspace[workspace.display]
+
+        // Save the most recent workspace if it's not the current one
+        if activeWorkspace[workspace.display]?.id != workspace.id {
+            mostRecentWorkspace[workspace.display] = activeWorkspace[workspace.display]
+        }
+
         activeWorkspace[workspace.display] = workspace
         activeWorkspaceSymbolIconName = workspace.symbolIconName
         showApps(in: workspace, setFocus: setFocus)

--- a/FlashSpace/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Workspaces/WorkspaceManager.swift
@@ -16,6 +16,7 @@ final class WorkspaceManager: ObservableObject {
 
     private(set) var activeWorkspace: [DisplayName: Workspace] = [:]
     private(set) var lastWorkspaceActivation = Date.distantPast
+    private(set) var mostRecentWorkspace: [DisplayName: Workspace] = [:]
 
     private var cancellables = Set<AnyCancellable>()
     private let hideAgainSubject = PassthroughSubject<Workspace, Never>()
@@ -87,6 +88,7 @@ extension WorkspaceManager {
         Integrations.runOnActivateIfNeeded(workspace: workspace)
 
         lastWorkspaceActivation = Date()
+        mostRecentWorkspace[workspace.display] = activeWorkspace[workspace.display]
         activeWorkspace[workspace.display] = workspace
         activeWorkspaceSymbolIconName = workspace.symbolIconName
         showApps(in: workspace, setFocus: setFocus)
@@ -114,6 +116,7 @@ extension WorkspaceManager {
     func getHotKeys() -> [(Shortcut, () -> ())] {
         let shortcuts = [
             getUnassignAppShortcut(),
+            getRecentWorkspaceShortcut(),
             getCycleWorkspacesShortcut(next: false),
             getCycleWorkspacesShortcut(next: true)
         ] +
@@ -194,6 +197,20 @@ extension WorkspaceManager {
             else { return }
 
             activateWorkspace(workspace, setFocus: true)
+        }
+
+        return (shortcut, action)
+    }
+
+    private func getRecentWorkspaceShortcut() -> (Shortcut, () -> ())? {
+        guard let shortcut = settingsRepository.switchToRecentWorkspace?.toShortcut() else { return nil }
+        let action = { [weak self] in
+            guard let self,
+                  let screen = getCursorScreen(),
+                  let mostRecentWorkspace = mostRecentWorkspace[screen]
+            else { return }
+
+            activateWorkspace(mostRecentWorkspace, setFocus: true)
         }
 
         return (shortcut, action)


### PR DESCRIPTION
Activate the Workspace that was most recently activated on the screen where the cursor is currently located.
I don't use external monitors, so I haven't tested this on multiple screens myself.

<img width="892" alt="image" src="https://github.com/user-attachments/assets/ba897159-245f-48cc-af31-eb8ca8168a10" />
