### PR TITLE
feat: added floating apps management

### DIFF
--- a/FlashSpace/Core/AppDependencies.swift
+++ b/FlashSpace/Core/AppDependencies.swift
@@ -40,7 +40,8 @@ struct AppDependencies {
         )
         self.focusedWindowTracker = FocusedWindowTracker(
             workspaceRepository: workspaceRepository,
-            workspaceManager: workspaceManager
+            workspaceManager: workspaceManager,
+            settingsRepository: settingsRepository
         )
 
         focusedWindowTracker.startTracking()

--- a/FlashSpace/Extensions/NSRunningApplication.swift
+++ b/FlashSpace/Extensions/NSRunningApplication.swift
@@ -89,4 +89,9 @@ extension NSRunningApplication {
             window.getFrame().flatMap { (window, $0) }
         }
     }
+
+    func isOnTheSameScreen(as workspace: Workspace) -> Bool {
+        let hasMoreScreens = NSScreen.screens.count > 1
+        return !hasMoreScreens || getFrame()?.getDisplay() == workspace.display
+    }
 }

--- a/FlashSpace/Focus/FocusedWindowTracker.swift
+++ b/FlashSpace/Focus/FocusedWindowTracker.swift
@@ -13,13 +13,16 @@ final class FocusedWindowTracker {
 
     private let workspaceRepository: WorkspaceRepository
     private let workspaceManager: WorkspaceManager
+    private let settingsRepository: SettingsRepository
 
     init(
         workspaceRepository: WorkspaceRepository,
-        workspaceManager: WorkspaceManager
+        workspaceManager: WorkspaceManager,
+        settingsRepository: SettingsRepository
     ) {
         self.workspaceRepository = workspaceRepository
         self.workspaceManager = workspaceManager
+        self.settingsRepository = settingsRepository
     }
 
     func startTracking() {
@@ -37,6 +40,9 @@ final class FocusedWindowTracker {
 
     private func activeApplicationChanged(_ app: NSRunningApplication) {
         guard Date().timeIntervalSince(workspaceManager.lastWorkspaceActivation) > 0.2 else { return }
+
+        // Skip if the app is floating
+        guard settingsRepository.floatingApps?.contains(app.localizedName ?? "") != true else { return }
 
         // Skip if the app exists in any active workspace
         guard !workspaceManager.activeWorkspace.values

--- a/FlashSpace/HotKeys/HotKeysManager.swift
+++ b/FlashSpace/HotKeys/HotKeysManager.swift
@@ -61,17 +61,6 @@ final class HotKeysManager {
             hotKeysMonitor.addAction(action, forKeyEvent: .down)
         }
 
-        if let floatTheFocusedApp = settingsRepository.floatTheFocusedApp?.toShortcut() {
-            let action = ShortcutAction(shortcut: floatTheFocusedApp) { [weak self] _ in
-                guard let activeApp = NSWorkspace.shared.frontmostApplication,
-                      let appName = activeApp.localizedName else { return true }
-
-                self?.settingsRepository.addFloatingAppIfNeeded(app: appName)
-                return true
-            }
-            hotKeysMonitor.addAction(action, forKeyEvent: .down)
-        }
-
         print("Enabled all shortcuts")
     }
 

--- a/FlashSpace/HotKeys/HotKeysManager.swift
+++ b/FlashSpace/HotKeys/HotKeysManager.swift
@@ -61,6 +61,17 @@ final class HotKeysManager {
             hotKeysMonitor.addAction(action, forKeyEvent: .down)
         }
 
+        if let floatTheFocusedApp = settingsRepository.floatTheFocusedApp?.toShortcut() {
+            let action = ShortcutAction(shortcut: floatTheFocusedApp) { [weak self] _ in
+                guard let activeApp = NSWorkspace.shared.frontmostApplication,
+                      let appName = activeApp.localizedName else { return true }
+
+                self?.settingsRepository.addFloatingAppIfNeeded(app: appName)
+                return true
+            }
+            hotKeysMonitor.addAction(action, forKeyEvent: .down)
+        }
+
         print("Enabled all shortcuts")
     }
 

--- a/FlashSpace/Settings/SettingsRepository.swift
+++ b/FlashSpace/Settings/SettingsRepository.swift
@@ -27,6 +27,10 @@ struct AppSettings: Codable {
     var switchToRecentWorkspace: HotKeyShortcut?
     var unassignFocusedApp: HotKeyShortcut?
 
+    var floatingApps: [String]?
+    var floatTheFocusedApp: HotKeyShortcut?
+    var unfloatTheFocusedApp: HotKeyShortcut?
+
     var enableIntegrations: Bool?
     var runScriptOnWorkspaceChange: String?
     var runScriptOnLaunch: String?
@@ -101,6 +105,18 @@ final class SettingsRepository: ObservableObject {
         didSet { updateSettings() }
     }
 
+    @Published var floatingApps: [String]? {
+        didSet { updateSettings() }
+    }
+
+    @Published var floatTheFocusedApp: HotKeyShortcut? {
+        didSet { updateSettings() }
+    }
+
+    @Published var unfloatTheFocusedApp: HotKeyShortcut? {
+        didSet { updateSettings() }
+    }
+
     // MARK: - Integrations
 
     @Published var enableIntegrations: Bool = false {
@@ -140,6 +156,19 @@ final class SettingsRepository: ObservableObject {
         }
     }
 
+    func addFloatingAppIfNeeded(app: String) {
+        var unwrappedFloatingApps = floatingApps ?? []
+        guard !unwrappedFloatingApps.contains(app) else { return }
+        unwrappedFloatingApps.append(app)
+        floatingApps = unwrappedFloatingApps
+        saveToDisk()
+    }
+
+    func deleteFloatingApp(app: String) {
+        floatingApps?.removeAll(where: { $0 == app })
+        saveToDisk()
+    }
+
     private func updateSettings() {
         guard shouldUpdate else { return }
 
@@ -161,6 +190,10 @@ final class SettingsRepository: ObservableObject {
             switchToNextWorkspace: switchToNextWorkspace,
             switchToRecentWorkspace: switchToRecentWorkspace,
             unassignFocusedApp: unassignFocusedApp,
+
+            floatingApps: floatingApps,
+            floatTheFocusedApp: floatTheFocusedApp,
+            unfloatTheFocusedApp: unfloatTheFocusedApp,
 
             enableIntegrations: enableIntegrations,
             runScriptOnWorkspaceChange: runScriptOnWorkspaceChange,
@@ -202,6 +235,10 @@ final class SettingsRepository: ObservableObject {
         switchToNextWorkspace = settings.switchToNextWorkspace
         switchToRecentWorkspace = settings.switchToRecentWorkspace
         unassignFocusedApp = settings.unassignFocusedApp
+
+        floatingApps = settings.floatingApps
+        floatTheFocusedApp = settings.floatTheFocusedApp
+        unfloatTheFocusedApp = settings.unfloatTheFocusedApp
 
         enableIntegrations = settings.enableIntegrations ?? false
         runScriptOnWorkspaceChange = settings.runScriptOnWorkspaceChange ?? Self.defaultScript

--- a/FlashSpace/Settings/SettingsRepository.swift
+++ b/FlashSpace/Settings/SettingsRepository.swift
@@ -165,7 +165,7 @@ final class SettingsRepository: ObservableObject {
     }
 
     func deleteFloatingApp(app: String) {
-        floatingApps?.removeAll(where: { $0 == app })
+        floatingApps?.removeAll { $0 == app }
         saveToDisk()
     }
 

--- a/FlashSpace/Settings/WorkspacesSettingsView.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsView.swift
@@ -40,30 +40,28 @@ struct WorkspacesSettingsView: View {
                     Button(action: viewModel.addFloatingApp) {
                         Image(systemName: "plus")
                     }
-                },
-                footer:
-                Text("Floating applications remain visible across all workspaces.")
-                    .foregroundStyle(.secondary)
-                    .font(.callout)
+                }
             ) {
                 VStack(alignment: .leading) {
-                    List(
+                    ForEach(
                         settings.floatingApps ?? [],
                         id: \.self
                     ) { app in
                         HStack {
-                            Text(app)
-                            Spacer()
                             Button {
                                 viewModel.deleteFloatingApp(app: app)
                             } label: {
-                                Image(systemName: "x.circle.fill")
-                            }
+                                Image(systemName: "x.circle.fill").opacity(0.8)
+                            }.buttonStyle(.borderless)
+                            Text(app)
                         }
                     }
                 }
                 hotkey("Float The Focused App", for: $settings.floatTheFocusedApp)
                 hotkey("Unfloat The Focused App", for: $settings.unfloatTheFocusedApp)
+                Text("Floating applications remain visible across all workspaces.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
             }
         }
         .formStyle(.grouped)

--- a/FlashSpace/Settings/WorkspacesSettingsView.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct WorkspacesSettingsView: View {
+    @StateObject var viewModel = WorkspacesSettingsViewModel()
     @StateObject var settings = AppDependencies.shared.settingsRepository
 
     var body: some View {
@@ -29,6 +30,33 @@ struct WorkspacesSettingsView: View {
                 )
                 .foregroundStyle(.secondary)
                 .font(.callout)
+            }
+
+            Section(
+                header:
+                HStack {
+                    Text("Floating Apps")
+                    Spacer()
+                    Button(action: viewModel.addFloatingApp) {
+                        Image(systemName: "plus")
+                    }
+
+                    Button(action: viewModel.deleteFloatingApp) {
+                        Image(systemName: "trash")
+                    }.disabled(viewModel.selectedFloatingApp == nil)
+                }
+            ) {
+                VStack(alignment: .leading) {
+                    List(
+                        settings.floatingApps ?? [],
+                        id: \.self,
+                        selection: $viewModel.selectedFloatingApp
+                    ) {
+                        Text($0)
+                    }
+                }
+                hotkey("Float The Focused App", for: $settings.floatTheFocusedApp)
+                hotkey("Unfloat The Focused App", for: $settings.unfloatTheFocusedApp)
             }
         }
         .formStyle(.grouped)

--- a/FlashSpace/Settings/WorkspacesSettingsView.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsView.swift
@@ -40,19 +40,26 @@ struct WorkspacesSettingsView: View {
                     Button(action: viewModel.addFloatingApp) {
                         Image(systemName: "plus")
                     }
-
-                    Button(action: viewModel.deleteFloatingApp) {
-                        Image(systemName: "trash")
-                    }.disabled(viewModel.selectedFloatingApp == nil)
-                }
+                },
+                footer:
+                Text("Floating applications remain visible across all workspaces.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
             ) {
                 VStack(alignment: .leading) {
                     List(
                         settings.floatingApps ?? [],
-                        id: \.self,
-                        selection: $viewModel.selectedFloatingApp
-                    ) {
-                        Text($0)
+                        id: \.self
+                    ) { app in
+                        HStack {
+                            Text(app)
+                            Spacer()
+                            Button {
+                                viewModel.deleteFloatingApp(app: app)
+                            } label: {
+                                Image(systemName: "x.circle.fill")
+                            }
+                        }
                     }
                 }
                 hotkey("Float The Focused App", for: $settings.floatTheFocusedApp)

--- a/FlashSpace/Settings/WorkspacesSettingsViewModel.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsViewModel.swift
@@ -4,8 +4,6 @@ import SwiftUI
 final class WorkspacesSettingsViewModel: ObservableObject {
     private let settingsRepository = AppDependencies.shared.settingsRepository
 
-    @Published var selectedFloatingApp: String?
-
     func addFloatingApp() {
         let fileChooser = FileChooser()
         let appUrl = fileChooser.runModalOpenPanel(
@@ -14,15 +12,12 @@ final class WorkspacesSettingsViewModel: ObservableObject {
         )
 
         guard let appUrl else { return }
-
-        let appName = appUrl.lastPathComponent.replacingOccurrences(of: ".app", with: "")
+        let appName = appUrl.bundle?.localizedAppName ?? appUrl.fileName
 
         settingsRepository.addFloatingAppIfNeeded(app: appName)
     }
 
-    func deleteFloatingApp() {
-        guard let appName = selectedFloatingApp else { return }
-        settingsRepository.deleteFloatingApp(app: appName)
-        selectedFloatingApp = nil
+    func deleteFloatingApp(app: String) {
+        settingsRepository.deleteFloatingApp(app: app)
     }
 }

--- a/FlashSpace/Settings/WorkspacesSettingsViewModel.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftUI
+
+final class WorkspacesSettingsViewModel: ObservableObject {
+    private let settingsRepository = AppDependencies.shared.settingsRepository
+
+    @Published var selectedFloatingApp: String?
+
+    func addFloatingApp() {
+        let fileChooser = FileChooser()
+        let appUrl = fileChooser.runModalOpenPanel(
+            allowedFileTypes: [.application],
+            directoryURL: URL(filePath: "/Applications")
+        )
+
+        guard let appUrl else { return }
+
+        let appName = appUrl.lastPathComponent.replacingOccurrences(of: ".app", with: "")
+
+        settingsRepository.addFloatingAppIfNeeded(app: appName)
+    }
+
+    func deleteFloatingApp() {
+        guard let appName = selectedFloatingApp else { return }
+        settingsRepository.deleteFloatingApp(app: appName)
+        selectedFloatingApp = nil
+    }
+}

--- a/FlashSpace/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Workspaces/WorkspaceManager.swift
@@ -195,11 +195,9 @@ extension WorkspaceManager {
         else { return nil }
 
         let action = { [weak self] in
-            guard let self else { return }
+            guard let self, let screen = getCursorScreen() else { return }
 
-            let cursorScreenWorkspaces = cursorScreenWorkspaces
-            guard let screen = cursorScreenWorkspaces.screen else { return }
-            var screenWorkspaces = cursorScreenWorkspaces.workspaces
+            var screenWorkspaces = workspaces(in: screen)
 
             if !next {
                 screenWorkspaces = screenWorkspaces.reversed()
@@ -254,8 +252,7 @@ extension WorkspaceManager {
 
             self.settingsRepository.deleteFloatingApp(app: appName)
 
-            let cursorScreenWorkspaces = cursorScreenWorkspaces
-            guard let screen = cursorScreenWorkspaces.screen else { return }
+            guard let screen = getCursorScreen() else { return }
             if activeWorkspace[screen]?.apps.contains(appName) != true {
                 activeApp.hide()
             }
@@ -271,13 +268,9 @@ extension WorkspaceManager {
             .localizedName
     }
 
-    private var cursorScreenWorkspaces: (screen: DisplayName?, workspaces: [Workspace]) {
-        let screen = getCursorScreen()
+    private func workspaces(in screen: DisplayName) -> [Workspace] {
         let hasMoreScreens = NSScreen.screens.count > 1
-        return (
-            screen,
-            workspaceRepository.workspaces
-                .filter { !hasMoreScreens || $0.display == screen }
-        )
+        return workspaceRepository.workspaces
+            .filter { !hasMoreScreens || $0.display == screen }
     }
 }


### PR DESCRIPTION
Apps set to `Floating App` are not affected by workspace switching.

This is useful for features that need to work across all workspaces, such as [KeyCastr](https://github.com/keycastr/keycastr).

Unfortunately, it would be nice if floating apps were always on top and focus was on the app set to `Focus App` within the workspace settings, but I didn't know which API to use so I couldn't support it.

I'd also appreciate your feedback on the naming.

https://github.com/user-attachments/assets/5548b2f0-a3fb-4199-ac27-08f005bdd0b6

