### PR TITLE
GitHub Action to run swiftformat, brew bundle, swiftlint, and xcodegen generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
       - run: swiftlint --reporter github-actions-logging --strict
       - run: xcodegen generate
       - run: ls -Fla FlashSpace.xcodeproj
+      - run: cat FlashSpace.xcodeproj/project.pbxproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - run: sw_vers && swift --version
       - uses: actions/checkout@v4
-      - run: swift run swiftlint --reporter github-actions-logging --strict || true  # No Package.swift file.
       - run: swiftformat .
-      - run: swift build || true  # No Package.swift file.
-      - run: swift test || true  # No Package.swift file.
+      - run: brew bundle
+      - run: xcodegen generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+# https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-swift
+# https://github.com/swift-actions/setup-swift
+
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        swift: ["5.10", "6.0"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: ${{ matrix.swift }}
+      - run: sw_vers && swift --version
+      - uses: actions/checkout@v4
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest]
         swift: ["5.10", "6.0"]
@@ -19,7 +20,7 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - run: sw_vers && swift --version
       - uses: actions/checkout@v4
-      - run: swift run swiftlint --reporter github-actions-logging --strict
+      - run: swift run swiftlint --reporter github-actions-logging --strict || true  # No Package.swift file.
       - run: |
           brew install swiftformat
           swiftformat .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: swiftformat .
       - run: brew bundle
+      - run: swiftlint --reporter github-actions-logging --strict
+      - run: brew install xcodegen
       - run: xcodegen generate
+      - run: cat FlashSpace/FlashSpace.xcodeproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       - run: sw_vers && swift --version
       - uses: actions/checkout@v4
       - run: swift run swiftlint --reporter github-actions-logging --strict || true  # No Package.swift file.
-      - run: |
-          brew install swiftformat
-          swiftformat .
+      - run: swiftformat .
       - run: swift build || true  # No Package.swift file.
       - run: swift test || true  # No Package.swift file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,4 @@ jobs:
       - run: brew bundle
       - run: swiftlint --reporter github-actions-logging --strict
       - run: xcodegen generate
-      - run: ls -Fla
-      - run: cat FlashSpace.xcodeproj
+      - run: ls -Fla FlashSpace.xcodeproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
       - run: swiftformat .
       - run: brew bundle
       - run: swiftlint --reporter github-actions-logging --strict
-      - run: brew install xcodegen
       - run: xcodegen generate
-      - run: cat FlashSpace/FlashSpace.xcodeproj
+      - run: ls -Fla
+      - run: cat FlashSpace.xcodeproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           swift-version: ${{ matrix.swift }}
       - run: sw_vers && swift --version
       - uses: actions/checkout@v4
-      - name: Build
-        run: swift build || true  # No Package.swift file.
-      - name: Run tests
-        run: swift test
+      - run: swift run swiftlint --reporter github-actions-logging --strict
+      - run: |
+          brew install swiftformat
+          swiftformat .
+      - run: swift build || true  # No Package.swift file.
+      - run: swift test || true  # No Package.swift file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,6 @@ jobs:
       - run: sw_vers && swift --version
       - uses: actions/checkout@v4
       - name: Build
-        run: swift build
+        run: swift build || true  # No Package.swift file.
       - name: Run tests
         run: swift test


### PR DESCRIPTION
# Test results: https://github.com/cclauss/FlashSpace/actions
* https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-swift
* https://github.com/swift-actions/setup-swift

% `swift build`
```
error: Could not find Package.swift in this directory or any of its parent directories.
```

---

 `swiftformat` passes but `swiftlint`, `swift build`, and `swift test` all fail without a `Package.swift` file.

If adding a `Package.swift` file, please remove ` || true` from these three lines so these steps become mandatory.

Is there a way to automatically generate a `Package.swift` file for this project or would that be a manual effort?