### PR TITLE
feat: added support for showing empty workspace

### DIFF
--- a/FlashSpace/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Workspaces/WorkspaceManager.swift
@@ -109,8 +109,12 @@ final class WorkspaceManager: ObservableObject {
         let regularApps = NSWorkspace.shared.runningApplications
             .filter { $0.activationPolicy == .regular }
         let workspaceApps = Set(workspace.apps + (settingsRepository.floatingApps ?? []))
+        let isAnyWorkspaceAppRunning = regularApps
+            .contains { workspaceApps.contains($0.localizedName ?? "") }
+
         let appsToHide = regularApps
             .filter { !workspaceApps.contains($0.localizedName ?? "") && !$0.isHidden }
+            .filter { isAnyWorkspaceAppRunning || $0.bundleURL?.fileName != "Finder" }
             .filter { $0.isOnTheSameScreen(as: workspace) }
 
         for app in appsToHide {
@@ -132,8 +136,9 @@ final class WorkspaceManager: ObservableObject {
         }
 
         let fallbackToLastApp = apps.first { $0.localizedName == workspace.apps.last }
+        let fallbackToFinder = NSWorkspace.shared.runningApplications.first { $0.bundleURL?.fileName == "Finder" }
 
-        return appToFocus ?? fallbackToLastApp
+        return appToFocus ?? fallbackToLastApp ?? fallbackToFinder
     }
 
     private func centerCursorIfNeeded(in frame: CGRect?) {


### PR DESCRIPTION
Requested in #59

macOS requires that at least one application must be active, which is why it's probably impossible to terminate Finder. Finder is unique because it can receive focus even when no window is visible. I use this feature to display an empty workspace.

However, be aware that if any Finder window is open, it will appear on the empty workspace. If you want to have an empty workspace, close all Finder's windows.