### PR TITLE
feat!: added icons for apps & workspaces

### DIFF
--- a/FlashSpace/App/AppConstants.swift
+++ b/FlashSpace/App/AppConstants.swift
@@ -8,7 +8,11 @@
 import AppKit
 
 enum AppConstants {
-    static let lastFocusedOption = "(Last Focused)"
+    static let lastFocusedOption = MacApp(
+        name: "(Last Focused)",
+        bundleIdentifier: "flashspace.last-focused",
+        iconPath: nil
+    )
 
     static var version: String {
         guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {

--- a/FlashSpace/Assets.xcassets/errorRed.colorset/Contents.json
+++ b/FlashSpace/Assets.xcassets/errorRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.0",
+          "blue" : "0x53",
+          "green" : "0x45",
+          "red" : "0xe6"
+        }
+      },
+      "idiom" : "universal"
+    },
+  ],
+  "info" : {
+     "author" : "xcode",
+     "version" : 1
+  }
+}

--- a/FlashSpace/Extensions/Bundle.swift
+++ b/FlashSpace/Extensions/Bundle.swift
@@ -19,4 +19,16 @@ extension Bundle {
         infoDictionary?["LSUIElement"] as? String == "1" ||
             infoDictionary?["LSUIElement"] as? Bool == true
     }
+
+    var iconPath: String {
+        let iconFile = infoDictionary?["CFBundleIconFile"] as? String
+            ?? infoDictionary?["CFBundleIconName"] as? String
+            ?? "AppIcon"
+
+        return bundleURL
+            .appendingPathComponent("Contents")
+            .appendingPathComponent("Resources")
+            .appendingPathComponent(iconFile.hasSuffix(".icns") ? iconFile : "\(iconFile).icns")
+            .path(percentEncoded: false)
+    }
 }

--- a/FlashSpace/Extensions/MacAppArray.swift
+++ b/FlashSpace/Extensions/MacAppArray.swift
@@ -1,0 +1,26 @@
+//
+//  MacAppArray.swift
+//
+//  Created by Wojciech Kulik on 06/02/2025.
+//  Copyright © 2025 Wojciech Kulik. All rights reserved.
+//
+
+import AppKit
+
+extension [MacApp] {
+    func firstIndex(ofAppWith bundleIdentifier: String) -> Int? {
+        firstIndex { $0.bundleIdentifier == bundleIdentifier }
+    }
+
+    func firstIndex(of app: NSRunningApplication) -> Int? {
+        firstIndex { $0.bundleIdentifier == app.bundleIdentifier }
+    }
+
+    func containsApp(with bundleIdentifier: String?) -> Bool {
+        contains { $0.bundleIdentifier == bundleIdentifier }
+    }
+
+    func containsApp(_ app: NSRunningApplication) -> Bool {
+        contains { $0.bundleIdentifier == app.bundleIdentifier }
+    }
+}

--- a/FlashSpace/Extensions/NSRunningApplication.swift
+++ b/FlashSpace/Extensions/NSRunningApplication.swift
@@ -8,8 +8,10 @@
 import AppKit
 
 extension NSRunningApplication {
+    var toMacApp: MacApp { .init(app: self) }
     var display: DisplayName? { frame?.getDisplay() }
     var frame: CGRect? { mainWindow?.frame }
+    var iconPath: String? { bundleURL?.iconPath }
 
     var mainWindow: AXUIElement? {
         var windowList: CFTypeRef?
@@ -102,5 +104,13 @@ extension NSRunningApplication {
 
     func isOnTheSameScreen(as workspace: Workspace) -> Bool {
         display == workspace.displayWithFallback
+    }
+}
+
+extension [NSRunningApplication] {
+    func find(_ app: MacApp?) -> NSRunningApplication? {
+        guard let app else { return nil }
+
+        return first { $0.bundleIdentifier == app.bundleIdentifier }
     }
 }

--- a/FlashSpace/Extensions/URL.swift
+++ b/FlashSpace/Extensions/URL.swift
@@ -11,6 +11,8 @@ extension URL {
     var bundle: Bundle? { Bundle(url: self) }
     var fileName: String { lastPathComponent.replacingOccurrences(of: ".app", with: "") }
     var appName: String { bundle?.localizedAppName ?? fileName }
+    var bundleIdentifier: String? { bundle?.bundleIdentifier }
+    var iconPath: String? { bundle?.iconPath }
 
     func createIntermediateDirectories() throws {
         try FileManager.default.createDirectory(

--- a/FlashSpace/Focus/FocusedWindowTracker.swift
+++ b/FlashSpace/Focus/FocusedWindowTracker.swift
@@ -41,23 +41,21 @@ final class FocusedWindowTracker {
     private func activeApplicationChanged(_ app: NSRunningApplication) {
         guard Date().timeIntervalSince(workspaceManager.lastWorkspaceActivation) > 0.2 else { return }
 
-        guard let appName = app.localizedName else { return }
-
         // Skip if the app is floating
-        guard settingsRepository.floatingApps?.contains(appName) != true else { return }
+        guard settingsRepository.floatingApps?.containsApp(app) != true else { return }
 
         // Skip if the app exists in any active workspace
         guard !workspaceManager.activeWorkspace.values
-            .contains(where: { $0.apps.contains(appName) }) else { return }
+            .contains(where: { $0.apps.containsApp(app) }) else { return }
 
         // Find the workspace that contains the app
         guard let workspace = workspaceRepository.workspaces
-            .first(where: { $0.apps.contains(appName) }) else { return }
+            .first(where: { $0.apps.containsApp(app) }) else { return }
 
         // Activate the workspace if it's not already active
         if workspaceManager.activeWorkspace[workspace.displayWithFallback]?.id != workspace.id {
             print("\n\nFound workspace for app: \(workspace.name)")
-            workspaceManager.updateLastFocusedApp(appName, in: workspace)
+            workspaceManager.updateLastFocusedApp(app.toMacApp, in: workspace)
             workspaceManager.activateWorkspace(workspace, setFocus: false)
             app.activate()
         }

--- a/FlashSpace/Focus/RunningApp.swift
+++ b/FlashSpace/Focus/RunningApp.swift
@@ -16,12 +16,14 @@ struct RunningApp {
     }
 
     let name: String
+    let bundleIdentifier: String
     let app: NSRunningApplication
     let windows: [AppWindow]
 
     init(app: NSRunningApplication) {
         self.app = app
         self.name = app.localizedName ?? ""
+        self.bundleIdentifier = app.bundleIdentifier ?? ""
         self.windows = app.allWindows
             .map { AppWindow(frame: $0.frame, title: $0.window.title ?? "", axWindow: $0.window) }
             .sorted { $0.title < $1.title || $0.title == $1.title && $0.frame.minX < $1.frame.minX }

--- a/FlashSpace/MainView.swift
+++ b/FlashSpace/MainView.swift
@@ -47,7 +47,15 @@ struct MainView: View {
                 id: \.self,
                 selection: $viewModel.selectedWorkspace
             ) { workspace in
-                Text(workspace.name)
+                HStack {
+                    Image(systemName: workspace.symbolIconName ?? "bolt.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 15, height: 15)
+                        .foregroundStyle(Color(hex: "#f9e2af")!)
+                    Text(workspace.name)
+                        .foregroundColor(workspace.apps.contains(where: \.bundleIdentifier.isEmpty) ? .errorRed : .primary)
+                }
             }
             .frame(width: 200, height: 350)
 
@@ -82,7 +90,16 @@ struct MainView: View {
                 id: \.self,
                 selection: $viewModel.selectedApp
             ) { app in
-                Text(app)
+                HStack {
+                    if let iconPath = app.iconPath, let image = NSImage(byReferencingFile: iconPath) {
+                        Image(nsImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 20, height: 20)
+                    }
+                    Text(app.name)
+                        .foregroundColor(app.bundleIdentifier.isEmpty ? .errorRed : .primary)
+                }
             }
             .frame(width: 200, height: 350)
 
@@ -120,7 +137,7 @@ struct MainView: View {
 
                 Picker("Focus App:", selection: $viewModel.workspaceAppToFocus) {
                     ForEach(viewModel.focusAppOptions, id: \.self) {
-                        Text($0).tag($0)
+                        Text($0.name).tag($0)
                     }
                 }.padding(.bottom)
 
@@ -141,6 +158,11 @@ struct MainView: View {
                 HotKeyControl(shortcut: $viewModel.workspaceAssignShortcut).padding(.bottom)
             }
             .disabled(viewModel.selectedWorkspace == nil)
+
+            if viewModel.workspaces.contains(where: { $0.apps.contains(where: \.bundleIdentifier.isEmpty) }) {
+                Text("Could not migrate some apps. Please re-add them to fix the problem. Please also check floating apps.")
+                    .foregroundColor(.errorRed)
+            }
 
             Spacer()
 

--- a/FlashSpace/Settings/SettingsRepository.swift
+++ b/FlashSpace/Settings/SettingsRepository.swift
@@ -33,7 +33,7 @@ struct AppSettings: Codable {
     var showFloatingNotifications: Bool?
     var changeWorkspaceOnAppAssign: Bool?
 
-    var floatingApps: [String]?
+    var floatingApps: [MacApp]?
     var floatTheFocusedApp: HotKeyShortcut?
     var unfloatTheFocusedApp: HotKeyShortcut?
 
@@ -130,7 +130,7 @@ final class SettingsRepository: ObservableObject {
         didSet { updateSettings() }
     }
 
-    @Published var floatingApps: [String]? {
+    @Published var floatingApps: [MacApp]? {
         didSet { updateSettings() }
     }
 
@@ -193,7 +193,7 @@ final class SettingsRepository: ObservableObject {
         }
     }
 
-    func addFloatingAppIfNeeded(app: String) {
+    func addFloatingAppIfNeeded(app: MacApp) {
         var unwrappedFloatingApps = floatingApps ?? []
         guard !unwrappedFloatingApps.contains(app) else { return }
         unwrappedFloatingApps.append(app)
@@ -201,9 +201,16 @@ final class SettingsRepository: ObservableObject {
         saveToDisk()
     }
 
-    func deleteFloatingApp(app: String) {
+    func deleteFloatingApp(app: MacApp) {
         floatingApps?.removeAll { $0 == app }
         saveToDisk()
+    }
+
+    func saveToDisk() {
+        guard let data = try? encoder.encode(currentSettings) else { return }
+
+        try? dataUrl.createIntermediateDirectories()
+        try? data.write(to: dataUrl)
     }
 
     private func updateSettings() {
@@ -245,13 +252,6 @@ final class SettingsRepository: ObservableObject {
         )
         saveToDisk()
         AppDependencies.shared.hotKeysManager.refresh()
-    }
-
-    private func saveToDisk() {
-        guard let data = try? encoder.encode(currentSettings) else { return }
-
-        try? dataUrl.createIntermediateDirectories()
-        try? data.write(to: dataUrl)
     }
 
     private func loadFromDisk() {

--- a/FlashSpace/Settings/WorkspacesSettingsView.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsView.swift
@@ -46,6 +46,12 @@ struct WorkspacesSettingsView: View {
                     }
                 }
             ) {
+                if settings.floatingApps?.contains(where: \.bundleIdentifier.isEmpty) == true {
+                    Text("Could not migrate some apps. Please re-add them to fix the problem.")
+                        .foregroundStyle(.errorRed)
+                        .font(.callout)
+                }
+
                 VStack(alignment: .leading) {
                     ForEach(settings.floatingApps ?? [], id: \.self) { app in
                         HStack {
@@ -55,7 +61,8 @@ struct WorkspacesSettingsView: View {
                                 Image(systemName: "x.circle.fill").opacity(0.8)
                             }.buttonStyle(.borderless)
 
-                            Text(app)
+                            Text(app.name)
+                                .foregroundStyle(app.bundleIdentifier.isEmpty ? .errorRed : .primary)
                         }
                     }
                 }

--- a/FlashSpace/Settings/WorkspacesSettingsViewModel.swift
+++ b/FlashSpace/Settings/WorkspacesSettingsViewModel.swift
@@ -11,12 +11,18 @@ final class WorkspacesSettingsViewModel: ObservableObject {
             directoryURL: URL(filePath: "/Applications")
         )
 
-        guard let appUrl else { return }
+        guard let bundle = appUrl?.bundle else { return }
 
-        settingsRepository.addFloatingAppIfNeeded(app: appUrl.appName)
+        settingsRepository.addFloatingAppIfNeeded(
+            app: .init(
+                name: bundle.localizedAppName,
+                bundleIdentifier: bundle.bundleIdentifier ?? "",
+                iconPath: bundle.iconPath
+            )
+        )
     }
 
-    func deleteFloatingApp(app: String) {
+    func deleteFloatingApp(app: MacApp) {
         settingsRepository.deleteFloatingApp(app: app)
     }
 }

--- a/FlashSpace/Workspaces/MacApp.swift
+++ b/FlashSpace/Workspaces/MacApp.swift
@@ -1,0 +1,74 @@
+//
+//  MacApp.swift
+//
+//  Created by Wojciech Kulik on 06/02/2025.
+//  Copyright © 2025 Wojciech Kulik. All rights reserved.
+//
+
+import AppKit
+
+enum Migrations {
+    static var appsMigrated = false
+}
+
+struct MacApp: Codable, Hashable, Equatable {
+    var name: String
+    var bundleIdentifier: String
+    var iconPath: String?
+
+    init(
+        name: String,
+        bundleIdentifier: String,
+        iconPath: String?
+    ) {
+        self.name = name
+        self.bundleIdentifier = bundleIdentifier
+        self.iconPath = iconPath
+    }
+
+    init(app: NSRunningApplication) {
+        self.name = app.localizedName ?? ""
+        self.bundleIdentifier = app.bundleIdentifier ?? ""
+        self.iconPath = app.iconPath
+    }
+
+    init(from decoder: any Decoder) throws {
+        if let app = try? decoder.singleValueContainer().decode(String.self) {
+            // V1 - migration
+            let runningApp = NSWorkspace.shared.runningApplications
+                .first { $0.localizedName == app }
+
+            self.name = app
+
+            if let runningApp {
+                self.bundleIdentifier = runningApp.bundleIdentifier ?? ""
+                self.iconPath = runningApp.iconPath
+            } else if let bundle = Bundle(path: "/Applications/\(app).app") {
+                self.bundleIdentifier = bundle.bundleIdentifier ?? ""
+                self.iconPath = bundle.iconPath
+            } else if let bundle = Bundle(path: "/System/Applications/\(app).app") {
+                self.bundleIdentifier = bundle.bundleIdentifier ?? ""
+                self.iconPath = bundle.iconPath
+            } else {
+                self.bundleIdentifier = ""
+                self.iconPath = nil
+            }
+
+            Migrations.appsMigrated = true
+        } else {
+            // V2
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.name = try container.decode(String.self, forKey: .name)
+            self.bundleIdentifier = try container.decode(String.self, forKey: .bundleIdentifier)
+            self.iconPath = try container.decodeIfPresent(String.self, forKey: .iconPath)
+        }
+    }
+
+    static func == (lhs: MacApp, rhs: MacApp) -> Bool {
+        if lhs.bundleIdentifier.isEmpty || rhs.bundleIdentifier.isEmpty {
+            return lhs.name == rhs.name
+        } else {
+            return lhs.bundleIdentifier == rhs.bundleIdentifier
+        }
+    }
+}

--- a/FlashSpace/Workspaces/Workspace.swift
+++ b/FlashSpace/Workspaces/Workspace.swift
@@ -27,8 +27,8 @@ struct Workspace: Identifiable, Codable, Hashable {
     var display: DisplayName
     var activateShortcut: HotKeyShortcut?
     var assignAppShortcut: HotKeyShortcut?
-    var apps: [String]
-    var appToFocus: String?
+    var apps: [MacApp]
+    var appToFocus: MacApp?
     var symbolIconName: String?
 }
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ sketchybar --set $NAME label="$WORKSPACE - $DISPLAY"
 sketchybar --add event flashspace_workspace_change
 
 SID=1
-WORKSPACES=$(cat ~/.config/flashspace/workspaces.json | jq -r ".[].name")
+SELECTED_PROFILE_ID=$(cat ~/.config/flashspace/profiles.json | jq -r ".selectedProfileId")
+WORKSPACES=$(cat ~/.config/flashspace/profiles.json | jq -r 'first(.profiles[] | select(.id == $id)) | .workspaces[].name' --arg id "$SELECTED_PROFILE_ID")
 
 for workspace in $WORKSPACES; do
   sketchybar --add item flashspace.$SID left \


### PR DESCRIPTION
BREAKING CHANGES:
- The structure of config files has been changed. Now apps contain more information (bundleIdentifier & iconPath).
- workspaces.json file is no longer used (everything is in profiles.json). If you used that file to obtain the list of workspaces, please see README (sketchybar section) to learn how to get the active profile.