### PR TITLE
docs: use CLI in sketchybar integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,7 @@ sketchybar --set $NAME label="$WORKSPACE - $DISPLAY"
 sketchybar --add event flashspace_workspace_change
 
 SID=1
-SELECTED_PROFILE_ID=$(jq -r ".selectedProfileId" ~/.config/flashspace/profiles.json)
-WORKSPACES=$(jq -r --arg id "$SELECTED_PROFILE_ID" 'first(.profiles[] | select(.id == $id)) | .workspaces[].name' ~/.config/flashspace/profiles.json)
+WORKSPACES=$(/Applications/FlashSpace.app/Contents/Resources/flashspace list-workspaces)
 
 for workspace in $WORKSPACES; do
   sketchybar --add item flashspace.$SID left \


### PR DESCRIPTION
Using full path to `flashspace` CLI to make example that will work for people that haven't installed CLI into `/usr/local/bin`.

---
FYI I haven't checked it in bash, since I'm using lua for my sketchybar configuration.
Since output of `jq` and `list-workspaces` looks the same (at least on my machine) I think it should behave in the same way.
Oh, and if you want to, I can also provide example configuration that uses [SbarLua](https://github.com/FelixKratz/SbarLua).