### PR TITLE
feat(gestures)!: add four finger swipe support

### DIFF
--- a/FlashSpace/Features/Gestures/SwipeManager.swift
+++ b/FlashSpace/Features/Gestures/SwipeManager.swift
@@ -40,6 +40,8 @@ final class SwipeManager {
 
     private var swipeThreshold: Double { gesturesSettings.swipeThreshold }
     private var naturalDirection: Bool { gesturesSettings.naturalDirection }
+    private var enableSwipeGesture: Bool { gesturesSettings.enableSwipeGesture }
+    private var swipeFingerCount: Int { gesturesSettings.swipeFingerCount.rawValue }
 
     private var eventTap: CFMachPort?
     private var horizontalSwipeSum: Float = 0
@@ -128,7 +130,7 @@ final class SwipeManager {
 
         if touchesCount == 0 {
             gestureFinished()
-        } else if touchesCount == 3 {
+        } else if touchesCount == swipeFingerCount, enableSwipeGesture {
             state = .began
             horizontalSwipeSum += horizontalSwipeDistance(touches: touches)
         }
@@ -147,7 +149,7 @@ final class SwipeManager {
             horizontalSwipeSum >= 0
         }
 
-        Logger.log("3 fingers swipe finished, direction: \(next ? "next" : "prev")")
+        Logger.log("\(swipeFingerCount) fingers swipe finished, direction: \(next ? "next" : "prev")")
         horizontalSwipeSum = 0.0
         prevTouchPositions.removeAll()
 

--- a/FlashSpace/Features/Gestures/SwipeManager.swift
+++ b/FlashSpace/Features/Gestures/SwipeManager.swift
@@ -40,7 +40,6 @@ final class SwipeManager {
 
     private var swipeThreshold: Double { gesturesSettings.swipeThreshold }
     private var naturalDirection: Bool { gesturesSettings.naturalDirection }
-    private var enableSwipeGesture: Bool { gesturesSettings.enableSwipeGesture }
     private var swipeFingerCount: Int { gesturesSettings.swipeFingerCount.rawValue }
 
     private var eventTap: CFMachPort?

--- a/FlashSpace/Features/Gestures/SwipeManager.swift
+++ b/FlashSpace/Features/Gestures/SwipeManager.swift
@@ -130,7 +130,7 @@ final class SwipeManager {
 
         if touchesCount == 0 {
             gestureFinished()
-        } else if touchesCount == swipeFingerCount, enableSwipeGesture {
+        } else if touchesCount == swipeFingerCount {
             state = .began
             horizontalSwipeSum += horizontalSwipeDistance(touches: touches)
         }

--- a/FlashSpace/Features/Gestures/SwipeManager.swift
+++ b/FlashSpace/Features/Gestures/SwipeManager.swift
@@ -20,7 +20,7 @@ final class SwipeManager {
     static let shared = SwipeManager()
 
     private var swipeThreshold: Double { gesturesSettings.swipeThreshold }
-    private var naturalDirection: Bool { gesturesSettings.naturalDirection }
+    private var naturalDirection: Bool { gesturesSettings.swipeNaturalDirection }
     private var swipeFingerCount: Int { gesturesSettings.swipeFingerCount.rawValue }
 
     private var eventTap: CFMachPort?

--- a/FlashSpace/Features/Settings/Gestures/GesturesSettings.swift
+++ b/FlashSpace/Features/Settings/Gestures/GesturesSettings.swift
@@ -31,7 +31,7 @@ final class GesturesSettings: ObservableObject {
         didSet { updateSwipeManager() }
     }
 
-    @Published var naturalDirection = false
+    @Published var swipeNaturalDirection = false
     @Published var swipeThreshold: Double = 0.2
 
     private var observer: AnyCancellable?
@@ -46,7 +46,7 @@ final class GesturesSettings: ObservableObject {
         observer = Publishers.MergeMany(
             $enableSwipeGesture.settingsPublisher(),
             $swipeFingerCount.settingsPublisher(),
-            $naturalDirection.settingsPublisher(),
+            $swipeNaturalDirection.settingsPublisher(),
             $swipeThreshold.settingsPublisher()
         )
         .receive(on: DispatchQueue.main)
@@ -71,7 +71,7 @@ extension GesturesSettings: SettingsProtocol {
         observer = nil
         enableSwipeGesture = appSettings.enableSwipeGesture ?? false
         swipeFingerCount = appSettings.swipeFingerCount == 4 ? .four : .three
-        naturalDirection = appSettings.naturalDirection ?? false
+        swipeNaturalDirection = appSettings.swipeNaturalDirection ?? false
         swipeThreshold = appSettings.swipeThreshold ?? 0.2
         observe()
     }
@@ -79,7 +79,7 @@ extension GesturesSettings: SettingsProtocol {
     func update(_ appSettings: inout AppSettings) {
         appSettings.enableSwipeGesture = enableSwipeGesture
         appSettings.swipeFingerCount = swipeFingerCount.rawValue
-        appSettings.naturalDirection = naturalDirection
+        appSettings.swipeNaturalDirection = swipeNaturalDirection
         appSettings.swipeThreshold = swipeThreshold
     }
 }

--- a/FlashSpace/Features/Settings/Gestures/GesturesSettings.swift
+++ b/FlashSpace/Features/Settings/Gestures/GesturesSettings.swift
@@ -70,7 +70,7 @@ extension GesturesSettings: SettingsProtocol {
     func load(from appSettings: AppSettings) {
         observer = nil
         enableSwipeGesture = appSettings.enableSwipeGesture ?? false
-        swipeFingerCount = appSettings.swipeFingerCount == 4 ? .four : .three
+        swipeFingerCount = appSettings.swipeFingerCount.flatMap(FingerCount.init(rawValue:)) ?? .three
         swipeNaturalDirection = appSettings.swipeNaturalDirection ?? false
         swipeThreshold = appSettings.swipeThreshold ?? 0.2
         observe()

--- a/FlashSpace/Features/Settings/Gestures/GesturesSettingsView.swift
+++ b/FlashSpace/Features/Settings/Gestures/GesturesSettingsView.swift
@@ -22,7 +22,7 @@ struct GesturesSettingsView: View {
                         }
                     }
 
-                    Toggle("Natural Direction", isOn: $settings.naturalDirection)
+                    Toggle("Natural Direction", isOn: $settings.swipeNaturalDirection)
 
                     HStack {
                         Text("Activation Threshold")

--- a/FlashSpace/Features/Settings/Gestures/GesturesSettingsView.swift
+++ b/FlashSpace/Features/Settings/Gestures/GesturesSettingsView.swift
@@ -12,10 +12,16 @@ struct GesturesSettingsView: View {
 
     var body: some View {
         Form {
-            Section("Three Fingers Swipe") {
-                Toggle("Enable Gestures", isOn: $settings.enableThreeFingersSwipe)
+            Section("Swipe Gestures") {
+                Toggle("Enable Swipe Gestures", isOn: $settings.enableSwipeGesture)
 
                 Group {
+                    Picker("Finger Count", selection: $settings.swipeFingerCount) {
+                        ForEach(GesturesSettings.FingerCount.allCases) { fingerCount in
+                            Text(fingerCount.description).tag(fingerCount)
+                        }
+                    }
+
                     Toggle("Natural Direction", isOn: $settings.naturalDirection)
 
                     HStack {
@@ -30,8 +36,8 @@ struct GesturesSettingsView: View {
                         ).labelsHidden()
                     }
                 }
-                .disabled(!settings.enableThreeFingersSwipe)
-                .opacity(settings.enableThreeFingersSwipe ? 1 : 0.5)
+                .disabled(!settings.enableSwipeGesture)
+                .opacity(settings.enableSwipeGesture ? 1 : 0.5)
 
                 Text("This gesture allows to switch between next and previous workspace.")
                     .foregroundStyle(.secondary)

--- a/FlashSpace/Features/Settings/_Models/AppSettings.swift
+++ b/FlashSpace/Features/Settings/_Models/AppSettings.swift
@@ -32,7 +32,7 @@ struct AppSettings: Codable {
     // Gestures
     var enableSwipeGesture: Bool?
     var swipeFingerCount: Int?
-    var naturalDirection: Bool?
+    var swipeNaturalDirection: Bool?
     var swipeThreshold: Double?
 
     // Workspaces

--- a/FlashSpace/Features/Settings/_Models/AppSettings.swift
+++ b/FlashSpace/Features/Settings/_Models/AppSettings.swift
@@ -30,7 +30,8 @@ struct AppSettings: Codable {
     var focusFrontmostWindow: Bool?
 
     // Gestures
-    var enableThreeFingersSwipe: Bool?
+    var enableSwipeGesture: Bool?
+    var swipeFingerCount: Int?
     var naturalDirection: Bool?
     var swipeThreshold: Double?
 

--- a/project.yml
+++ b/project.yml
@@ -30,7 +30,7 @@ targets:
     sources: [FlashSpace]
     settings:
       base:
-        MARKETING_VERSION: 2.7.35
+        MARKETING_VERSION: 2.8.35
         CURRENT_PROJECT_VERSION: 35
         CODE_SIGN_ENTITLEMENTS: FlashSpace/FlashSpace.entitlements
         DEVELOPMENT_TEAM: "${XCODE_DEVELOPMENT_TEAM}"

--- a/project.yml
+++ b/project.yml
@@ -30,8 +30,8 @@ targets:
     sources: [FlashSpace]
     settings:
       base:
-        MARKETING_VERSION: 2.7.34
-        CURRENT_PROJECT_VERSION: 34
+        MARKETING_VERSION: 2.7.35
+        CURRENT_PROJECT_VERSION: 35
         CODE_SIGN_ENTITLEMENTS: FlashSpace/FlashSpace.entitlements
         DEVELOPMENT_TEAM: "${XCODE_DEVELOPMENT_TEAM}"
         ENABLE_HARDENED_RUNTIME: true


### PR DESCRIPTION
Resolves #230 

Breaking Changes (config):
- renamed `enableThreeFingersSwipe` to `enableSwipeGesture`
- renamed `naturalDirection` to `swipeNaturalDirection`

Code changes:
- Added support for configurable swipe gestures (3 or 4 fingers)
- Refactored the Gesture settings UI to have a top-level enable switch and a finger count selection
menu
- Simplified gesture configuration with unified controls.