### PR TITLE
feat(workspaces): user-defined Picture-in-Picture apps

### DIFF
--- a/FlashSpace/Features/PictureInPicture/Extensions/AXUIElement+PiP.swift
+++ b/FlashSpace/Features/PictureInPicture/Extensions/AXUIElement+PiP.swift
@@ -8,13 +8,24 @@
 import AppKit
 
 extension AXUIElement {
-    func isPictureInPicture(bundleId: String?) -> Bool {
-        guard let browser = PipBrowser(rawValue: bundleId ?? "") else { return false }
+    private var pipApps: [PipApp] {
+        AppDependencies.shared.workspaceSettings.pipApps
+    }
 
-        if let pipWindowTitle = browser.title {
-            return title == pipWindowTitle
-        } else if let pipWindowSubrole = browser.subrole {
-            return subrole == pipWindowSubrole
+    func isPictureInPicture(bundleId: String?) -> Bool {
+        if let browser = PipBrowser(rawValue: bundleId ?? "") {
+            if let pipWindowTitle = browser.title {
+                return title == pipWindowTitle
+            } else if let pipWindowSubrole = browser.subrole {
+                return subrole == pipWindowSubrole
+            }
+        } else if let pipApp = pipApps.first(where: { $0.bundleIdentifier == bundleId }) {
+            let result = title?.range(
+                of: pipApp.pipWindowTitleRegex,
+                options: .regularExpression
+            ) != nil
+
+            return result
         }
 
         return false

--- a/FlashSpace/Features/PictureInPicture/Extensions/NSRunningApplication+PiP.swift
+++ b/FlashSpace/Features/PictureInPicture/Extensions/NSRunningApplication+PiP.swift
@@ -9,10 +9,15 @@ import AppKit
 
 extension NSRunningApplication {
     var supportsPictureInPicture: Bool {
-        PipBrowser.allCases.contains { $0.bundleId == bundleIdentifier }
+        PipBrowser.allCases.contains { $0.bundleId == bundleIdentifier } ||
+            pipApps.contains { $0.bundleIdentifier == bundleIdentifier }
     }
 
     var isPictureInPictureActive: Bool {
         allWindows.map(\.window).contains { $0.isPictureInPicture(bundleId: bundleIdentifier) }
+    }
+
+    private var pipApps: [PipApp] {
+        AppDependencies.shared.workspaceSettings.pipApps
     }
 }

--- a/FlashSpace/Features/PictureInPicture/Models/PipApp.swift
+++ b/FlashSpace/Features/PictureInPicture/Models/PipApp.swift
@@ -1,0 +1,14 @@
+//
+//  PipApp.swift
+//
+//  Created by Wojciech Kulik on 22/03/2025.
+//  Copyright © 2025 Wojciech Kulik. All rights reserved.
+//
+
+import Foundation
+
+struct PipApp: Codable, Equatable, Hashable {
+    let name: String
+    let bundleIdentifier: String
+    let pipWindowTitleRegex: String
+}

--- a/FlashSpace/Features/Settings/FloatingApps/FloatingAppsSettingsView.swift
+++ b/FlashSpace/Features/Settings/FloatingApps/FloatingAppsSettingsView.swift
@@ -20,7 +20,13 @@ struct FloatingAppsSettingsView: View {
                         .font(.callout)
                 }
 
-                appsList
+                if settings.floatingApps.isEmpty {
+                    Text("(no floating apps added)")
+                        .foregroundStyle(.secondary)
+                        .font(.callout)
+                } else {
+                    appsList
+                }
 
                 Text("Floating applications remain visible across all workspaces.")
                     .foregroundStyle(.secondary)

--- a/FlashSpace/Features/Settings/Workspaces/WorkspaceSettings.swift
+++ b/FlashSpace/Features/Settings/Workspaces/WorkspaceSettings.swift
@@ -21,11 +21,20 @@ final class WorkspaceSettings: ObservableObject {
     @Published var switchToNextWorkspace: AppHotKey?
 
     @Published var alternativeDisplays = ""
+    @Published var pipApps: [PipApp] = []
 
     private var observer: AnyCancellable?
     private let updateSubject = PassthroughSubject<(), Never>()
 
     init() { observe() }
+
+    func addPipApp(_ app: PipApp) {
+        pipApps.append(app)
+    }
+
+    func deletePipApp(_ app: PipApp) {
+        pipApps.removeAll { $0 == app }
+    }
 
     private func observe() {
         observer = Publishers.MergeMany(
@@ -38,7 +47,8 @@ final class WorkspaceSettings: ObservableObject {
             $switchToRecentWorkspace.settingsPublisher(),
             $switchToPreviousWorkspace.settingsPublisher(),
             $switchToNextWorkspace.settingsPublisher(),
-            $alternativeDisplays.settingsPublisher(debounce: true)
+            $alternativeDisplays.settingsPublisher(debounce: true),
+            $pipApps.settingsPublisher()
         )
         .receive(on: DispatchQueue.main)
         .sink { [weak self] in self?.updateSubject.send() }
@@ -64,6 +74,7 @@ extension WorkspaceSettings: SettingsProtocol {
         switchToNextWorkspace = appSettings.switchToNextWorkspace
 
         alternativeDisplays = appSettings.alternativeDisplays ?? ""
+        pipApps = appSettings.pipApps ?? []
         observe()
     }
 
@@ -80,5 +91,6 @@ extension WorkspaceSettings: SettingsProtocol {
         appSettings.switchToNextWorkspace = switchToNextWorkspace
 
         appSettings.alternativeDisplays = alternativeDisplays
+        appSettings.pipApps = pipApps
     }
 }

--- a/FlashSpace/Features/Settings/Workspaces/WorkspaceSettingsViewModel.swift
+++ b/FlashSpace/Features/Settings/Workspaces/WorkspaceSettingsViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  WorkspaceSettingsViewModel.swift
+//
+//  Created by Wojciech Kulik on 22/03/2025.
+//  Copyright © 2025 Wojciech Kulik. All rights reserved.
+//
+
+import Foundation
+
+final class WorkspaceSettingsViewModel: ObservableObject {
+    @Published var windowTitleRegex = ""
+    @Published var isInputDialogPresented = false {
+        didSet {
+            if !isInputDialogPresented, windowTitleRegex.isNotEmpty {
+                addPendingPipApp()
+                windowTitleRegex = ""
+            }
+        }
+    }
+
+    private var pendingApp: PipApp?
+    private let settings = AppDependencies.shared.workspaceSettings
+
+    func addPipApp() {
+        let fileChooser = FileChooser()
+        let appUrl = fileChooser.runModalOpenPanel(
+            allowedFileTypes: [.application],
+            directoryURL: URL(filePath: "/Applications")
+        )
+
+        guard let bundle = appUrl?.bundle else { return }
+
+        pendingApp = PipApp(
+            name: bundle.localizedAppName,
+            bundleIdentifier: bundle.bundleIdentifier ?? "",
+            pipWindowTitleRegex: ""
+        )
+        isInputDialogPresented = true
+    }
+
+    func deletePipApp(_ app: PipApp) {
+        settings.deletePipApp(app)
+    }
+
+    private func addPendingPipApp() {
+        guard let pendingApp else { return }
+
+        settings.addPipApp(
+            .init(
+                name: pendingApp.name,
+                bundleIdentifier: pendingApp.bundleIdentifier,
+                pipWindowTitleRegex: windowTitleRegex
+            )
+        )
+        self.pendingApp = nil
+    }
+}

--- a/FlashSpace/Features/Settings/_Models/AppSettings.swift
+++ b/FlashSpace/Features/Settings/_Models/AppSettings.swift
@@ -45,6 +45,7 @@ struct AppSettings: Codable {
     var unassignFocusedApp: AppHotKey?
     var toggleFocusedAppAssignment: AppHotKey?
     var alternativeDisplays: String?
+    var pipApps: [PipApp]?
 
     // Floating apps
     var floatingApps: [MacApp]?

--- a/FlashSpace/UI/InputDialog.swift
+++ b/FlashSpace/UI/InputDialog.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InputDialog: View {
     let title: String
+    var placeholder = "Type here..."
 
     @Binding var userInput: String
     @Binding var isPresented: Bool
@@ -18,7 +19,7 @@ struct InputDialog: View {
             Text(title)
                 .font(.headline)
 
-            TextField("Type here...", text: $userInput)
+            TextField(placeholder, text: $userInput)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding(.vertical, 8.0)
                 .onSubmit { isPresented = false }

--- a/project.yml
+++ b/project.yml
@@ -30,7 +30,7 @@ targets:
     sources: [FlashSpace]
     settings:
       base:
-        MARKETING_VERSION: 2.7.35
+        MARKETING_VERSION: 2.8.35
         CURRENT_PROJECT_VERSION: 35
         CODE_SIGN_ENTITLEMENTS: FlashSpace/FlashSpace.entitlements
         DEVELOPMENT_TEAM: "${XCODE_DEVELOPMENT_TEAM}"


### PR DESCRIPTION
Resolves #221

You can now select an app and specify a regex pattern for Picture-in-Picture window title. The matched window will remain visible when switching workspaces, while other windows from the same app will be hidden in the screen corner.

To add custom apps go to: Settings -> Workspaces.