### PR TITLE
feat(workspaces): remember floating app as "Last Focused"

### DIFF
--- a/FlashSpace/Features/FloatingApps/FloatingAppsHotKeys.swift
+++ b/FlashSpace/Features/FloatingApps/FloatingAppsHotKeys.swift
@@ -63,14 +63,6 @@ extension FloatingAppsHotKeys {
               let appName = activeApp.localizedName else { return }
 
         floatingAppsSettings.addFloatingAppIfNeeded(app: activeApp.toMacApp)
-
-        // Update the lastFocusedApp history for all workspaces on the same display
-        if let display = activeApp.display {
-            for workspace in workspaceManager.activeWorkspace.values where workspace.displayWithFallback == display {
-                workspaceManager.updateLastFocusedApp(activeApp.toMacApp, in: workspace)
-            }
-        }
-
         Toast.showWith(
             icon: "macwindow.on.rectangle",
             message: "\(appName) - Added To Floating Apps",

--- a/FlashSpace/Features/FloatingApps/FloatingAppsHotKeys.swift
+++ b/FlashSpace/Features/FloatingApps/FloatingAppsHotKeys.swift
@@ -63,6 +63,14 @@ extension FloatingAppsHotKeys {
               let appName = activeApp.localizedName else { return }
 
         floatingAppsSettings.addFloatingAppIfNeeded(app: activeApp.toMacApp)
+
+        // Update the lastFocusedApp history for all workspaces on the same display
+        if let display = activeApp.display {
+            for workspace in workspaceManager.activeWorkspace.values where workspace.displayWithFallback == display {
+                workspaceManager.updateLastFocusedApp(activeApp.toMacApp, in: workspace)
+            }
+        }
+
         Toast.showWith(
             icon: "macwindow.on.rectangle",
             message: "\(appName) - Added To Floating Apps",

--- a/FlashSpace/Features/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceManager.swift
@@ -88,7 +88,8 @@ final class WorkspaceManager: ObservableObject {
                 guard let self else { return }
 
                 if let activeWorkspace = activeWorkspace[application.display ?? ""],
-                   activeWorkspace.apps.containsApp(application) {
+                   activeWorkspace.apps.containsApp(application) ||
+                   floatingAppsSettings.floatingApps.containsApp(application) {
                     lastFocusedApp[activeWorkspace.id] = application.toMacApp
                     updateActiveWorkspace(activeWorkspace)
                 }

--- a/FlashSpace/Features/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceManager.swift
@@ -87,21 +87,10 @@ final class WorkspaceManager: ObservableObject {
             .sink { [weak self] application in
                 guard let self else { return }
 
-                // Track focused app for the workspace it belongs to
                 if let activeWorkspace = activeWorkspace[application.display ?? ""],
                    activeWorkspace.apps.containsApp(application) {
                     lastFocusedApp[activeWorkspace.id] = application.toMacApp
                     updateActiveWorkspace(activeWorkspace)
-                }
-
-                // Also track floating apps for workspaces on the same display
-                if floatingAppsSettings.floatingApps.containsApp(application) {
-                    let displayName = application.display ?? ""
-
-                    // Store the floating app as the last focused app for all workspaces on the same display
-                    for workspace in activeWorkspace.values where workspace.displayWithFallback == displayName {
-                        lastFocusedApp[workspace.id] = application.toMacApp
-                    }
                 }
             }
     }
@@ -178,16 +167,12 @@ final class WorkspaceManager: ObservableObject {
     ) -> NSRunningApplication? {
         var appToFocus: NSRunningApplication?
 
-        // First, try to use explicit appToFocus from workspace
-        if let explicitApp = workspace.appToFocus {
-            appToFocus = apps.find(explicitApp)
-        }
-        // Next, try last focused app for this workspace (including floating apps)
-        else if let lastFocused = lastFocusedApp[workspace.id] {
-            appToFocus = apps.find(lastFocused)
+        if workspace.appToFocus == nil {
+            appToFocus = apps.find(lastFocusedApp[workspace.id])
+        } else {
+            appToFocus = apps.find(workspace.appToFocus)
         }
 
-        // Fallback options if neither is available or found
         let fallbackToLastApp = apps.findFirstMatch(with: workspace.apps.reversed())
         let fallbackToFinder = NSWorkspace.shared.runningApplications.first {
             $0.bundleIdentifier == "com.apple.finder"


### PR DESCRIPTION
  1. Modified the observeFocus() method in WorkspaceManager to track both:
    - Regular apps belonging to a specific workspace
    - Floating apps for all workspaces on the same display
  2. Updated the findAppToFocus() method to make the logic clearer when selecting which app to focus,
  prioritizing:
    - Explicitly set app to focus in workspace
    - Last focused app in that workspace (now including floating apps)
    - Fallback to other apps in the workspace
  3. Enhanced the floatApp() method to update the lastFocusedApp history for all workspaces on the same
  display when an app is made floating