### PR TITLE
feat(workspaces): add Workspaces menubar item

### DIFF
--- a/FlashSpace/Features/CLI/Commands/ListCommands.swift
+++ b/FlashSpace/Features/CLI/Commands/ListCommands.swift
@@ -13,6 +13,7 @@ final class ListCommands: CommandExecutor {
     var profilesRepository: ProfilesRepository { AppDependencies.shared.profilesRepository }
     var settingsRepository: SettingsRepository { AppDependencies.shared.settingsRepository }
 
+    // swiftlint:disable:next function_body_length
     func execute(command: CommandRequest) -> CommandResponse? {
         switch command {
         case .listWorkspaces(let withDisplay, let profileName):

--- a/FlashSpace/Features/HotKeys/Extensions/AppHotKey+KeyboardShortcut.swift
+++ b/FlashSpace/Features/HotKeys/Extensions/AppHotKey+KeyboardShortcut.swift
@@ -8,16 +8,37 @@
 import SwiftUI
 
 extension AppHotKey {
-    var keyboardShortcut: KeyboardShortcut? {
+    var toKeyboardShortcut: KeyboardShortcut? {
         let components = value.components(separatedBy: "+")
         let modifiers = toEventModifiers(value)
 
-        guard let key = components.last else { return nil }
+        guard let key = components.last,
+              let keyEquivalent = stringToKeyEquivalent(key) else { return nil }
 
         return KeyboardShortcut(
-            KeyEquivalent(Character(key)),
+            keyEquivalent,
             modifiers: modifiers
         )
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func stringToKeyEquivalent(_ value: String) -> KeyEquivalent? {
+        guard value.count > 1 else { return KeyEquivalent(Character(value)) }
+
+        switch value {
+        case "esc", "escape": return KeyEquivalent.escape
+        case "return", "enter": return KeyEquivalent.return
+        case "tab": return KeyEquivalent.tab
+        case "space": return KeyEquivalent.space
+        case "delete", "backspace": return KeyEquivalent.delete
+        case "up": return KeyEquivalent.upArrow
+        case "down": return KeyEquivalent.downArrow
+        case "left": return KeyEquivalent.leftArrow
+        case "right": return KeyEquivalent.rightArrow
+        case "home": return KeyEquivalent.home
+        case "end": return KeyEquivalent.end
+        default: return nil
+        }
     }
 
     private func toEventModifiers(_ value: String) -> EventModifiers {

--- a/FlashSpace/Features/HotKeys/Extensions/AppHotKey+KeyboardShortcut.swift
+++ b/FlashSpace/Features/HotKeys/Extensions/AppHotKey+KeyboardShortcut.swift
@@ -1,0 +1,34 @@
+//
+//  AppHotKey+KeyboardShortcut.swift
+//
+//  Created by Wojciech Kulik on 31/05/2025.
+//  Copyright © 2025 Wojciech Kulik. All rights reserved.
+//
+
+import SwiftUI
+
+extension AppHotKey {
+    var keyboardShortcut: KeyboardShortcut? {
+        let components = value.components(separatedBy: "+")
+        let modifiers = toEventModifiers(value)
+
+        guard let key = components.last else { return nil }
+
+        return KeyboardShortcut(
+            KeyEquivalent(Character(key)),
+            modifiers: modifiers
+        )
+    }
+
+    private func toEventModifiers(_ value: String) -> EventModifiers {
+        let flags = value.lowercased().split(separator: "+").map { String($0) }
+        var result: EventModifiers = []
+
+        if flags.contains("cmd") { result.insert(.command) }
+        if flags.contains("ctrl") { result.insert(.control) }
+        if flags.contains("opt") { result.insert(.option) }
+        if flags.contains("shift") { result.insert(.shift) }
+
+        return result
+    }
+}

--- a/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
+++ b/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
@@ -52,22 +52,15 @@ struct FlashSpaceMenuBar: Scene {
             }.hidden(profilesRepository.profiles.count < 2)
 
             Menu("Workspaces") {
-                ForEach(workspaceRepository.workspaces.sorted(by: { $0.name < $1.name })) { workspace in
-                    Button(action: {
+                ForEach(workspaceRepository.workspaces) { workspace in
+                    Button {
                         workspaceManager.activateWorkspace(workspace, setFocus: true)
-                    }) {
-                        HStack {
-                            Text(workspace.name)
-                            Spacer()
-                            if let shortcut = workspace.activateShortcut?.value, !shortcut.isEmpty {
-                                Text(shortcut)
-                                    .foregroundColor(.secondary)
-                                    .font(.caption)
-                            }
-                        }
+                    } label: {
+                        Text(workspace.name)
                     }
+                    .keyboardShortcut(workspace.activateShortcut?.keyboardShortcut)
                 }
-            }.hidden(workspaceRepository.workspaces.isEmpty)
+            }.hidden(workspaceRepository.workspaces.count < 2)
 
             Divider()
 

--- a/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
+++ b/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
@@ -13,6 +13,7 @@ struct FlashSpaceMenuBar: Scene {
     @StateObject private var workspaceManager = AppDependencies.shared.workspaceManager
     @StateObject private var settingsRepository = AppDependencies.shared.settingsRepository
     @StateObject private var profilesRepository = AppDependencies.shared.profilesRepository
+    @StateObject private var workspaceRepository = AppDependencies.shared.workspaceRepository
 
     var body: some Scene {
         MenuBarExtra {
@@ -49,6 +50,24 @@ struct FlashSpaceMenuBar: Scene {
                     )
                 }
             }.hidden(profilesRepository.profiles.count < 2)
+            
+            Menu("Workspaces") {
+                ForEach(workspaceRepository.workspaces.sorted(by: { $0.name < $1.name })) { workspace in
+                    Button(action: {
+                        workspaceManager.activateWorkspace(workspace, setFocus: true)
+                    }) {
+                        HStack {
+                            Text(workspace.name)
+                            Spacer()
+                            if let shortcut = workspace.activateShortcut?.value, !shortcut.isEmpty {
+                                Text(shortcut)
+                                    .foregroundColor(.secondary)
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                }
+            }.hidden(workspaceRepository.workspaces.isEmpty)
 
             Divider()
 

--- a/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
+++ b/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
@@ -50,7 +50,7 @@ struct FlashSpaceMenuBar: Scene {
                     )
                 }
             }.hidden(profilesRepository.profiles.count < 2)
-            
+
             Menu("Workspaces") {
                 ForEach(workspaceRepository.workspaces.sorted(by: { $0.name < $1.name })) { workspace in
                     Button(action: {

--- a/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
+++ b/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
@@ -58,7 +58,7 @@ struct FlashSpaceMenuBar: Scene {
                     } label: {
                         Text(workspace.name)
                     }
-                    .keyboardShortcut(workspace.activateShortcut?.keyboardShortcut)
+                    .keyboardShortcut(workspace.activateShortcut?.toKeyboardShortcut)
                 }
             }.hidden(workspaceRepository.workspaces.count < 2)
 

--- a/FlashSpace/Features/Workspaces/WorkspaceRepository.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceRepository.swift
@@ -6,10 +6,11 @@
 //
 
 import AppKit
+import Combine
 import Foundation
 
-final class WorkspaceRepository {
-    private(set) var workspaces: [Workspace] = []
+final class WorkspaceRepository: ObservableObject {
+    @Published private(set) var workspaces: [Workspace] = []
 
     private let profilesRepository: ProfilesRepository
 


### PR DESCRIPTION
- Sometimes I forget what Activate short key I've assigned to a workspace and I'd like to view / select a Workspaces directly from the menu bar without having to open the Flashspace window.  