### PR TITLE
feat: add Picture-in-Picture support for Comet browser

### DIFF
--- a/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
+++ b/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
@@ -17,12 +17,13 @@ enum PipBrowser: String, CaseIterable {
     case zen = "app.zen-browser.zen"
     case arc = "company.thebrowser.Browser"
     case dia = "company.thebrowser.dia"
+    case comet = "ai.perplexity.comet"
 
     var bundleId: String { rawValue }
 
     var title: String? {
         switch self {
-        case .chrome, .vivaldi, .brave, .opera:
+        case .chrome, .vivaldi, .brave, .opera, .comet:
             return "Picture in Picture"
         case .zen, .firefox:
             return "Picture-in-Picture"


### PR DESCRIPTION
Resolves #385

## Summary
• Add Comet browser (`ai.perplexity.comet`) to PipBrowser enum
• Configure Comet to use standard Chromium "Picture in Picture" title