### PR TITLE
feat(workspaces): add option to open apps on workspace activation

### DIFF
--- a/FlashSpace/Features/CLI/Commands/WorkspaceCommands.swift
+++ b/FlashSpace/Features/CLI/Commands/WorkspaceCommands.swift
@@ -18,7 +18,8 @@ final class WorkspaceCommands: CommandExecutor {
         case .activateWorkspace(.some(let name), _, let clean):
             let workspace = workspaceRepository.workspaces.first { $0.name == name }
             if let workspace {
-                if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation != true {
+                if workspace.isDynamic, workspace.displays.isEmpty,
+                   workspace.apps.isEmpty || workspace.openAppsOnActivation != true {
                     return CommandResponse(success: false, error: "\(workspace.name) - No Running Apps To Show")
                 }
                 workspaceManager.activateWorkspace(workspace, setFocus: true)
@@ -31,7 +32,8 @@ final class WorkspaceCommands: CommandExecutor {
         case .activateWorkspace(_, .some(let number), let clean):
             let workspace = workspaceRepository.workspaces[safe: number - 1]
             if let workspace {
-                if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation != true {
+                if workspace.isDynamic, workspace.displays.isEmpty,
+                   workspace.apps.isEmpty || workspace.openAppsOnActivation != true {
                     return CommandResponse(success: false, error: "\(workspace.name) - No Running Apps To Show")
                 }
                 workspaceManager.activateWorkspace(workspace, setFocus: true)

--- a/FlashSpace/Features/CLI/Commands/WorkspaceCommands.swift
+++ b/FlashSpace/Features/CLI/Commands/WorkspaceCommands.swift
@@ -18,7 +18,7 @@ final class WorkspaceCommands: CommandExecutor {
         case .activateWorkspace(.some(let name), _, let clean):
             let workspace = workspaceRepository.workspaces.first { $0.name == name }
             if let workspace {
-                if workspace.isDynamic, workspace.displays.isEmpty {
+                if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation != true {
                     return CommandResponse(success: false, error: "\(workspace.name) - No Running Apps To Show")
                 }
                 workspaceManager.activateWorkspace(workspace, setFocus: true)
@@ -31,7 +31,7 @@ final class WorkspaceCommands: CommandExecutor {
         case .activateWorkspace(_, .some(let number), let clean):
             let workspace = workspaceRepository.workspaces[safe: number - 1]
             if let workspace {
-                if workspace.isDynamic, workspace.displays.isEmpty {
+                if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation != true {
                     return CommandResponse(success: false, error: "\(workspace.name) - No Running Apps To Show")
                 }
                 workspaceManager.activateWorkspace(workspace, setFocus: true)

--- a/FlashSpace/Features/CLI/Commands/WorkspaceCommands.swift
+++ b/FlashSpace/Features/CLI/Commands/WorkspaceCommands.swift
@@ -110,6 +110,10 @@ final class WorkspaceCommands: CommandExecutor {
             }
         }
 
+        if let openApps = request.openApps {
+            workspace.openAppsOnActivation = openApps
+        }
+
         workspaceRepository.updateWorkspace(workspace)
         NotificationCenter.default.post(name: .appsListChanged, object: nil)
 

--- a/FlashSpace/Features/CLI/Models/CreateWorkspaceRequest.swift
+++ b/FlashSpace/Features/CLI/Models/CreateWorkspaceRequest.swift
@@ -14,6 +14,7 @@ struct CreateWorkspaceRequest: Codable {
     let icon: String?
     let activateKey: String?
     let assignKey: String?
+    let openApps: Bool
     let activate: Bool
 }
 
@@ -27,7 +28,8 @@ extension CreateWorkspaceRequest {
             assignAppShortcut: assignKey.flatMap { .init(value: $0) },
             apps: [],
             appToFocus: nil,
-            symbolIconName: icon
+            symbolIconName: icon,
+            openAppsOnActivation: openApps
         )
     }
 }

--- a/FlashSpace/Features/CLI/Models/UpdateWorkspaceRequest.swift
+++ b/FlashSpace/Features/CLI/Models/UpdateWorkspaceRequest.swift
@@ -15,4 +15,5 @@ struct UpdateWorkspaceRequest: Codable {
 
     let name: String?
     let display: Display?
+    let openApps: Bool?
 }

--- a/FlashSpace/Features/MainScreen/MainViewModel.swift
+++ b/FlashSpace/Features/MainScreen/MainViewModel.swift
@@ -42,6 +42,10 @@ final class MainViewModel: ObservableObject {
         didSet { saveWorkspace() }
     }
 
+    @Published var isOpenAppsOnActivationEnabled = false {
+        didSet { saveWorkspace() }
+    }
+
     @Published var isSymbolPickerPresented = false
     @Published var isInputDialogPresented = false
     @Published var userInput = ""
@@ -143,6 +147,7 @@ final class MainViewModel: ObservableObject {
         workspaceApps = selectedWorkspace?.apps
         workspaceAppToFocus = selectedWorkspace?.appToFocus ?? AppConstants.lastFocusedOption
         workspaceSymbolIconName = selectedWorkspace?.symbolIconName
+        isOpenAppsOnActivationEnabled = selectedWorkspace?.openAppsOnActivation ?? false
         selectedWorkspace.flatMap { selectedWorkspaces = [$0] }
     }
 
@@ -173,7 +178,8 @@ extension MainViewModel {
             assignAppShortcut: workspaceAssignShortcut,
             apps: selectedWorkspace.apps,
             appToFocus: workspaceAppToFocus == AppConstants.lastFocusedOption ? nil : workspaceAppToFocus,
-            symbolIconName: workspaceSymbolIconName
+            symbolIconName: workspaceSymbolIconName,
+            openAppsOnActivation: isOpenAppsOnActivationEnabled
         )
 
         workspaceRepository.updateWorkspace(updatedWorkspace)

--- a/FlashSpace/Features/MainScreen/WorkspaceConfigurationView.swift
+++ b/FlashSpace/Features/MainScreen/WorkspaceConfigurationView.swift
@@ -62,6 +62,13 @@ struct WorkspaceConfigurationView: View {
                 }
             }.padding(.bottom)
 
+            HStack {
+                Text("Open apps on activation:")
+                Toggle("", isOn: $viewModel.isOpenAppsOnActivationEnabled)
+                    .labelsHidden()
+            }
+            .padding(.bottom)
+
             Text("Activate Shortcut:")
             HotKeyControl(shortcut: $viewModel.workspaceShortcut).padding(.bottom)
 

--- a/FlashSpace/Features/MainScreen/WorkspaceConfigurationView.swift
+++ b/FlashSpace/Features/MainScreen/WorkspaceConfigurationView.swift
@@ -62,18 +62,13 @@ struct WorkspaceConfigurationView: View {
                 }
             }.padding(.bottom)
 
-            HStack {
-                Text("Open apps on activation:")
-                Toggle("", isOn: $viewModel.isOpenAppsOnActivationEnabled)
-                    .labelsHidden()
-            }
-            .padding(.bottom)
-
             Text("Activate Shortcut:")
             HotKeyControl(shortcut: $viewModel.workspaceShortcut).padding(.bottom)
 
             Text("Assign App Shortcut:")
             HotKeyControl(shortcut: $viewModel.workspaceAssignShortcut).padding(.bottom)
+
+            Toggle("Open apps on activation", isOn: $viewModel.isOpenAppsOnActivationEnabled).padding(.bottom)
         }
         .disabled(viewModel.selectedWorkspace == nil)
     }

--- a/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
+++ b/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
@@ -54,7 +54,8 @@ struct FlashSpaceMenuBar: Scene {
             Menu("Workspaces") {
                 ForEach(workspaceRepository.workspaces) { workspace in
                     Button {
-                        if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation != true {
+                        if workspace.isDynamic, workspace.displays.isEmpty,
+                           workspace.apps.isEmpty || workspace.openAppsOnActivation != true {
                             Toast.showWith(
                                 icon: "square.stack.3d.up",
                                 message: "\(workspace.name) - No Running Apps To Show",

--- a/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
+++ b/FlashSpace/Features/MenuBar/FlashSpaceMenuBar.swift
@@ -54,7 +54,7 @@ struct FlashSpaceMenuBar: Scene {
             Menu("Workspaces") {
                 ForEach(workspaceRepository.workspaces) { workspace in
                     Button {
-                        if workspace.isDynamic, workspace.displays.isEmpty {
+                        if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation != true {
                             Toast.showWith(
                                 icon: "square.stack.3d.up",
                                 message: "\(workspace.name) - No Running Apps To Show",

--- a/FlashSpace/Features/Settings/About/AboutSettingsView.swift
+++ b/FlashSpace/Features/Settings/About/AboutSettingsView.swift
@@ -46,6 +46,11 @@ struct AboutSettingsView: View {
                     Spacer()
                     Button("GitHub") { openGitHub("brodmo") }
                 }
+                HStack {
+                    Text("Mattia Cerutti (@mattiacerutti)")
+                    Spacer()
+                    Button("GitHub") { openGitHub("mattiacerutti") }
+                }
             }
         }
         .buttonStyle(.accessoryBarAction)

--- a/FlashSpace/Features/Workspaces/Models/Workspace.swift
+++ b/FlashSpace/Features/Workspaces/Models/Workspace.swift
@@ -20,6 +20,7 @@ struct Workspace: Identifiable, Codable, Hashable {
         case apps
         case appToFocus
         case symbolIconName
+        case openAppsOnActivation
     }
 
     var id: WorkspaceID
@@ -30,6 +31,7 @@ struct Workspace: Identifiable, Codable, Hashable {
     var apps: [MacApp]
     var appToFocus: MacApp?
     var symbolIconName: String?
+    var openAppsOnActivation: Bool?
 }
 
 extension Workspace {

--- a/FlashSpace/Features/Workspaces/WorkspaceHotKeys.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceHotKeys.swift
@@ -49,7 +49,7 @@ final class WorkspaceHotKeys {
         let action = { [weak self] in
             guard let self, let updatedWorkspace = workspaceRepository.findWorkspace(with: workspace.id) else { return }
 
-            if updatedWorkspace.isDynamic, updatedWorkspace.displays.isEmpty {
+            if updatedWorkspace.isDynamic, updatedWorkspace.displays.isEmpty, updatedWorkspace.openAppsOnActivation != true {
                 Toast.showWith(
                     icon: "square.stack.3d.up",
                     message: "\(workspace.name) - No Running Apps To Show",

--- a/FlashSpace/Features/Workspaces/WorkspaceHotKeys.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceHotKeys.swift
@@ -49,7 +49,8 @@ final class WorkspaceHotKeys {
         let action = { [weak self] in
             guard let self, let updatedWorkspace = workspaceRepository.findWorkspace(with: workspace.id) else { return }
 
-            if updatedWorkspace.isDynamic, updatedWorkspace.displays.isEmpty, updatedWorkspace.openAppsOnActivation != true {
+            if updatedWorkspace.isDynamic, updatedWorkspace.displays.isEmpty,
+               workspace.apps.isEmpty || updatedWorkspace.openAppsOnActivation != true {
                 Toast.showWith(
                     icon: "square.stack.3d.up",
                     message: "\(workspace.name) - No Running Apps To Show",

--- a/FlashSpace/Features/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceManager.swift
@@ -353,7 +353,8 @@ extension WorkspaceManager {
         Logger.log("----")
         SpaceControl.hide()
 
-        if workspace.isDynamic, workspace.displays.isEmpty, workspace.openAppsOnActivation == true {
+        if workspace.isDynamic, workspace.displays.isEmpty,
+           workspace.apps.isNotEmpty, workspace.openAppsOnActivation == true {
             Logger.log("No running apps in the workspace - launching apps")
             openAppsIfNeeded(in: workspace)
 

--- a/FlashSpaceCLI/Sources/Subcommands/Workspace/CreateWorkspaceCommand.swift
+++ b/FlashSpaceCLI/Sources/Subcommands/Workspace/CreateWorkspaceCommand.swift
@@ -14,6 +14,7 @@ struct CreateWorkspaceRequest: Codable {
     let icon: String?
     let activateKey: String?
     let assignKey: String?
+    let openApps: Bool
     let activate: Bool
 }
 
@@ -38,6 +39,9 @@ struct CreateWorkspaceCommand: ParsableCommand {
     @Option(help: "The hotkey to assign the app")
     var assignKey: String?
 
+    @Flag(help: "Open apps on workspace activation")
+    var openApps = false
+
     @Flag(help: "Activate the new workspace")
     var activate = false
 
@@ -48,6 +52,7 @@ struct CreateWorkspaceCommand: ParsableCommand {
             icon: icon,
             activateKey: activateKey,
             assignKey: assignKey,
+            openApps: openApps,
             activate: activate
         )
         sendCommand(.createWorkspace(request))

--- a/FlashSpaceCLI/Sources/Subcommands/Workspace/UpdateWorkspaceCommand.swift
+++ b/FlashSpaceCLI/Sources/Subcommands/Workspace/UpdateWorkspaceCommand.swift
@@ -17,6 +17,7 @@ struct UpdateWorkspaceRequest: Codable {
 
     let name: String?
     let display: Display?
+    let openApps: Bool?
 }
 
 struct UpdateWorkspaceCommand: ParsableCommand {
@@ -34,14 +35,17 @@ struct UpdateWorkspaceCommand: ParsableCommand {
     @Option(help: "The name of the display to be assigned.")
     var display: String?
 
+    @Option(help: .init("Open apps on workspace activation (default: false)", valueName: "true|false"))
+    var openApps: Bool?
+
     @Flag(help: "Assign active display.")
     var activeDisplay = false
 
     func run() throws {
         if let display {
-            sendCommand(.updateWorkspace(.init(name: workspace, display: .name(display))))
+            sendCommand(.updateWorkspace(.init(name: workspace, display: .name(display), openApps: openApps)))
         } else if activeDisplay {
-            sendCommand(.updateWorkspace(.init(name: workspace, display: .active)))
+            sendCommand(.updateWorkspace(.init(name: workspace, display: .active, openApps: openApps)))
         } else {
             throw CommandError.operationFailed("Invalid command")
         }


### PR DESCRIPTION
This PR adds the feature requested in #375.

Key changes:
- In the workspace configuration there is a new checkbox which allows to set the "Open apps on workspace activation" setting for each single workspace (as suggested).
