### PR TITLE
feat(space-control): add Hide Empty Workspaces toggle and tile filtering

### DIFF
--- a/FlashSpace/Extensions/NSWorkspace.swift
+++ b/FlashSpace/Extensions/NSWorkspace.swift
@@ -1,0 +1,14 @@
+//
+//  NSWorkspace.swift
+//
+//  Created by Wojciech Kulik on 14/09/2025.
+//  Copyright © 2025 Wojciech Kulik. All rights reserved.
+//
+
+import AppKit
+
+extension NSWorkspace {
+    var runningRegularApps: [NSRunningApplication] {
+        runningApplications.filter { $0.activationPolicy == .regular }
+    }
+}

--- a/FlashSpace/Features/FocusManager/FocusManager.swift
+++ b/FlashSpace/Features/FocusManager/FocusManager.swift
@@ -10,8 +10,7 @@ import Foundation
 
 final class FocusManager {
     var visibleApps: [NSRunningApplication] {
-        NSWorkspace.shared.runningApplications
-            .filter { $0.activationPolicy == .regular && !$0.isHidden }
+        NSWorkspace.shared.runningRegularApps.filter { !$0.isHidden }
     }
 
     var focusedApp: NSRunningApplication? { NSWorkspace.shared.frontmostApplication }

--- a/FlashSpace/Features/Settings/About/AboutSettingsView.swift
+++ b/FlashSpace/Features/Settings/About/AboutSettingsView.swift
@@ -51,6 +51,11 @@ struct AboutSettingsView: View {
                     Spacer()
                     Button("GitHub") { openGitHub("mattiacerutti") }
                 }
+                HStack {
+                    Text("Peter (@peterneutron)")
+                    Spacer()
+                    Button("GitHub") { openGitHub("peterneutron") }
+                }
             }
         }
         .buttonStyle(.accessoryBarAction)

--- a/FlashSpace/Features/Settings/SpaceControl/SpaceControlSettings.swift
+++ b/FlashSpace/Features/Settings/SpaceControl/SpaceControlSettings.swift
@@ -14,6 +14,7 @@ final class SpaceControlSettings: ObservableObject {
     @Published var enableSpaceControlAnimations = true
     @Published var enableSpaceControlTilesAnimations = true
     @Published var spaceControlCurrentDisplayWorkspaces = false
+    @Published var spaceControlHideEmptyWorkspaces = false
     @Published var spaceControlUpdateScreenshotsOnOpen = false
     @Published var spaceControlNumberOfColumns = 0
 
@@ -29,6 +30,7 @@ final class SpaceControlSettings: ObservableObject {
             $enableSpaceControlAnimations.settingsPublisher(),
             $enableSpaceControlTilesAnimations.settingsPublisher(),
             $spaceControlCurrentDisplayWorkspaces.settingsPublisher(),
+            $spaceControlHideEmptyWorkspaces.settingsPublisher(),
             $spaceControlUpdateScreenshotsOnOpen.settingsPublisher(),
             $spaceControlNumberOfColumns.settingsPublisher(debounce: true)
         )
@@ -49,6 +51,7 @@ extension SpaceControlSettings: SettingsProtocol {
         enableSpaceControlAnimations = appSettings.enableSpaceControlAnimations ?? true
         enableSpaceControlTilesAnimations = appSettings.enableSpaceControlTilesAnimations ?? true
         spaceControlCurrentDisplayWorkspaces = appSettings.spaceControlCurrentDisplayWorkspaces ?? false
+        spaceControlHideEmptyWorkspaces = appSettings.spaceControlHideEmptyWorkspaces ?? false
         spaceControlUpdateScreenshotsOnOpen = appSettings.spaceControlUpdateScreenshotsOnOpen ?? false
         spaceControlNumberOfColumns = appSettings.spaceControlNumberOfColumns ?? 0
         observe()
@@ -60,6 +63,7 @@ extension SpaceControlSettings: SettingsProtocol {
         appSettings.enableSpaceControlAnimations = enableSpaceControlAnimations
         appSettings.enableSpaceControlTilesAnimations = enableSpaceControlTilesAnimations
         appSettings.spaceControlCurrentDisplayWorkspaces = spaceControlCurrentDisplayWorkspaces
+        appSettings.spaceControlHideEmptyWorkspaces = spaceControlHideEmptyWorkspaces
         appSettings.spaceControlUpdateScreenshotsOnOpen = spaceControlUpdateScreenshotsOnOpen
         appSettings.spaceControlNumberOfColumns = spaceControlNumberOfColumns
     }

--- a/FlashSpace/Features/Settings/SpaceControl/SpaceControlSettingsView.swift
+++ b/FlashSpace/Features/Settings/SpaceControl/SpaceControlSettingsView.swift
@@ -57,6 +57,10 @@ struct SpaceControlSettingsView: View {
                         isOn: $settings.spaceControlCurrentDisplayWorkspaces
                     )
                     Toggle(
+                        "Hide Empty Workspaces",
+                        isOn: $settings.spaceControlHideEmptyWorkspaces
+                    )
+                    Toggle(
                         "Update Screenshots On Open (slower)",
                         isOn: $settings.spaceControlUpdateScreenshotsOnOpen
                     )

--- a/FlashSpace/Features/Settings/_Models/AppSettings.swift
+++ b/FlashSpace/Features/Settings/_Models/AppSettings.swift
@@ -84,6 +84,7 @@ struct AppSettings: Codable {
     var enableSpaceControlAnimations: Bool?
     var enableSpaceControlTilesAnimations: Bool?
     var spaceControlCurrentDisplayWorkspaces: Bool?
+    var spaceControlHideEmptyWorkspaces: Bool?
     var spaceControlUpdateScreenshotsOnOpen: Bool?
     var spaceControlNumberOfColumns: Int?
 

--- a/FlashSpace/Features/SpaceControl/SpaceControl.swift
+++ b/FlashSpace/Features/SpaceControl/SpaceControl.swift
@@ -143,7 +143,7 @@ enum SpaceControl {
             .filter { !settings.spaceControlCurrentDisplayWorkspaces || $0.isOnTheCurrentScreen }
 
         if settings.spaceControlHideEmptyWorkspaces {
-            workspaces = workspaces.withoutEmpty()
+            workspaces = workspaces.skipWithoutRunningApps()
         }
 
         if workspaces.count < 2 {

--- a/FlashSpace/Features/SpaceControl/SpaceControl.swift
+++ b/FlashSpace/Features/SpaceControl/SpaceControl.swift
@@ -139,23 +139,14 @@ enum SpaceControl {
     }
 
     private static func validate() -> Bool {
-        let workspaces = AppDependencies.shared.workspaceRepository.workspaces
+        var workspaces = AppDependencies.shared.workspaceRepository.workspaces
             .filter { !settings.spaceControlCurrentDisplayWorkspaces || $0.isOnTheCurrentScreen }
 
-        let consideredWorkspaces: [Workspace]
         if settings.spaceControlHideEmptyWorkspaces {
-            let runningBundleIds = NSWorkspace.shared.runningApplications
-                .filter { $0.activationPolicy == .regular }
-                .compactMap(\.bundleIdentifier)
-                .asSet
-            consideredWorkspaces = workspaces.filter { ws in
-                ws.apps.contains { runningBundleIds.contains($0.bundleIdentifier) }
-            }
-        } else {
-            consideredWorkspaces = workspaces
+            workspaces = workspaces.withoutEmpty()
         }
 
-        if consideredWorkspaces.count < 2 {
+        if workspaces.count < 2 {
             Alert.showOkAlert(title: "Space Control", message: "You need at least 2 workspaces to use Space Control.")
             return false
         }

--- a/FlashSpace/Features/SpaceControl/Views/SpaceControlViewModel.swift
+++ b/FlashSpace/Features/SpaceControl/Views/SpaceControlViewModel.swift
@@ -67,7 +67,7 @@ final class SpaceControlViewModel: ObservableObject {
             .filter { !settings.spaceControlCurrentDisplayWorkspaces || $0.isOnTheCurrentScreen }
 
         if settings.spaceControlHideEmptyWorkspaces {
-            sourceWorkspaces = sourceWorkspaces.withoutEmpty()
+            sourceWorkspaces = sourceWorkspaces.skipWithoutRunningApps()
         }
 
         workspaces = Array(

--- a/FlashSpace/Features/SpaceControl/Views/SpaceControlViewModel.swift
+++ b/FlashSpace/Features/SpaceControl/Views/SpaceControlViewModel.swift
@@ -63,20 +63,11 @@ final class SpaceControlViewModel: ObservableObject {
         let activeWorkspaceIds = workspaceManager.activeWorkspace.map(\.value.id).asSet
         let mainDisplay = NSScreen.main?.localizedName ?? ""
 
-        // Base list respecting current-display filter
         var sourceWorkspaces = workspaceRepository.workspaces
             .filter { !settings.spaceControlCurrentDisplayWorkspaces || $0.isOnTheCurrentScreen }
 
-        // Optionally hide empty workspaces (no running assigned apps)
         if settings.spaceControlHideEmptyWorkspaces {
-            let runningBundleIds = NSWorkspace.shared.runningApplications
-                .filter { $0.activationPolicy == .regular }
-                .compactMap(\.bundleIdentifier)
-                .asSet
-
-            sourceWorkspaces = sourceWorkspaces.filter { ws in
-                ws.apps.contains { runningBundleIds.contains($0.bundleIdentifier) }
-            }
+            sourceWorkspaces = sourceWorkspaces.withoutEmpty()
         }
 
         workspaces = Array(

--- a/FlashSpace/Features/SpaceControl/Views/SpaceControlViewModel.swift
+++ b/FlashSpace/Features/SpaceControl/Views/SpaceControlViewModel.swift
@@ -63,9 +63,24 @@ final class SpaceControlViewModel: ObservableObject {
         let activeWorkspaceIds = workspaceManager.activeWorkspace.map(\.value.id).asSet
         let mainDisplay = NSScreen.main?.localizedName ?? ""
 
+        // Base list respecting current-display filter
+        var sourceWorkspaces = workspaceRepository.workspaces
+            .filter { !settings.spaceControlCurrentDisplayWorkspaces || $0.isOnTheCurrentScreen }
+
+        // Optionally hide empty workspaces (no running assigned apps)
+        if settings.spaceControlHideEmptyWorkspaces {
+            let runningBundleIds = NSWorkspace.shared.runningApplications
+                .filter { $0.activationPolicy == .regular }
+                .compactMap(\.bundleIdentifier)
+                .asSet
+
+            sourceWorkspaces = sourceWorkspaces.filter { ws in
+                ws.apps.contains { runningBundleIds.contains($0.bundleIdentifier) }
+            }
+        }
+
         workspaces = Array(
-            workspaceRepository.workspaces
-                .filter { !settings.spaceControlCurrentDisplayWorkspaces || $0.isOnTheCurrentScreen }
+            sourceWorkspaces
                 .prefix(35)
                 .enumerated()
                 .map {

--- a/FlashSpace/Features/Workspaces/Models/Workspace.swift
+++ b/FlashSpace/Features/Workspaces/Models/Workspace.swift
@@ -80,7 +80,7 @@ extension Workspace {
 }
 
 extension [Workspace] {
-    func withoutEmpty() -> [Workspace] {
+    func skipWithoutRunningApps() -> [Workspace] {
         let runningBundleIds = NSWorkspace.shared.runningRegularApps
             .compactMap(\.bundleIdentifier)
             .asSet

--- a/FlashSpace/Features/Workspaces/Models/Workspace.swift
+++ b/FlashSpace/Features/Workspaces/Models/Workspace.swift
@@ -44,8 +44,8 @@ extension Workspace {
             // prevents from detecting the correct display.
             //
             // The workaround is to activate the app manually to update its frame.
-            return NSWorkspace.shared.runningApplications
-                .filter { $0.activationPolicy == .regular && apps.containsApp($0) }
+            return NSWorkspace.shared.runningRegularApps
+                .filter { apps.containsApp($0) }
                 .flatMap(\.allDisplays)
                 .asSet
         } else {
@@ -76,5 +76,17 @@ extension Workspace {
 
     private var displayManager: DisplayManager {
         AppDependencies.shared.displayManager
+    }
+}
+
+extension [Workspace] {
+    func withoutEmpty() -> [Workspace] {
+        let runningBundleIds = NSWorkspace.shared.runningRegularApps
+            .compactMap(\.bundleIdentifier)
+            .asSet
+
+        return filter {
+            $0.apps.contains { runningBundleIds.contains($0.bundleIdentifier) }
+        }
     }
 }

--- a/FlashSpace/Features/Workspaces/WorkspaceManager.swift
+++ b/FlashSpace/Features/Workspaces/WorkspaceManager.swift
@@ -141,8 +141,7 @@ final class WorkspaceManager: ObservableObject {
     }
 
     private func showApps(in workspace: Workspace, setFocus: Bool, on displays: Set<DisplayName>) {
-        let regularApps = NSWorkspace.shared.runningApplications
-            .filter { $0.activationPolicy == .regular }
+        let regularApps = NSWorkspace.shared.runningRegularApps
         let floatingApps = floatingAppsSettings.floatingApps
         let hiddenApps = appsHiddenManually[workspace.id] ?? []
         var appsToShow = regularApps
@@ -187,8 +186,7 @@ final class WorkspaceManager: ObservableObject {
     }
 
     private func hideApps(in workspace: Workspace) {
-        let regularApps = NSWorkspace.shared.runningApplications
-            .filter { $0.activationPolicy == .regular }
+        let regularApps = NSWorkspace.shared.runningRegularApps
         let workspaceApps = workspace.apps + floatingAppsSettings.floatingApps
         let isAnyWorkspaceAppRunning = regularApps
             .contains { workspaceApps.containsApp($0) }
@@ -304,8 +302,7 @@ final class WorkspaceManager: ObservableObject {
             return
         }
 
-        let hiddenApps = NSWorkspace.shared.runningApplications
-            .filter { $0.activationPolicy == .regular }
+        let hiddenApps = NSWorkspace.shared.runningRegularApps
             .filter { $0.isHidden || $0.isMinimized }
 
         for activeWorkspace in activeWorkspace.values {
@@ -513,8 +510,7 @@ extension WorkspaceManager {
         var selectedWorkspace = nextWorkspaces.first ?? (loop ? screenWorkspaces.first : nil)
 
         if skipEmpty {
-            let runningApps = NSWorkspace.shared.runningApplications
-                .filter { $0.activationPolicy == .regular }
+            let runningApps = NSWorkspace.shared.runningRegularApps
                 .compactMap(\.bundleIdentifier)
                 .asSet
 


### PR DESCRIPTION
Exactly what the title says 😅. Adds a `Hide Empty Workspaces` toggle in `Settings -> Space Control` that when enabled hides empty workspace tiles.