### PR TITLE
fix(pip): match both Chrome PiP title variants

### DIFF
--- a/FlashSpace/Features/PictureInPicture/Extensions/AXUIElement+PiP.swift
+++ b/FlashSpace/Features/PictureInPicture/Extensions/AXUIElement+PiP.swift
@@ -19,11 +19,13 @@ extension AXUIElement {
 
         if let browser {
             if let partialTitle = browser.partialTitle,
-               title?.contains(partialTitle) == true {
+               windowTitle?.range(of: partialTitle, options: .caseInsensitive) != nil {
                 return true
             }
 
-            if let windowTitle, browser.titles.contains(windowTitle) {
+            if let windowTitle, browser.titles.contains(where: {
+                windowTitle.caseInsensitiveCompare($0) == .orderedSame
+            }) {
                 return true
             }
 

--- a/FlashSpace/Features/PictureInPicture/Extensions/AXUIElement+PiP.swift
+++ b/FlashSpace/Features/PictureInPicture/Extensions/AXUIElement+PiP.swift
@@ -23,7 +23,7 @@ extension AXUIElement {
                 return true
             }
 
-            if let pipWindowTitle = browser.title, windowTitle == pipWindowTitle {
+            if let windowTitle, browser.titles.contains(windowTitle) {
                 return true
             }
 

--- a/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
+++ b/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
@@ -30,7 +30,6 @@ enum PipBrowser: String, CaseIterable {
             // "Picture-in-picture" (document PiP, some sites/older builds).
             return ["Picture in Picture", "Picture-in-picture"]
         case .zen, .firefox:
-            // Gecko-based browsers use a single hyphenated title.
             return ["Picture-in-Picture"]
         case .arc, .dia:
             return []

--- a/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
+++ b/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
@@ -22,16 +22,17 @@ enum PipBrowser: String, CaseIterable {
 
     var bundleId: String { rawValue }
 
-    var title: String? {
+    var titles: [String] {
         switch self {
         case .chrome:
-            return "Picture-in-picture"
+            // Chrome has shipped both variants across versions.
+            return ["Picture-in-picture", "Picture in Picture"]
         case .vivaldi, .brave, .opera, .comet, .edge:
-            return "Picture in Picture"
+            return ["Picture in Picture"]
         case .zen, .firefox:
-            return "Picture-in-Picture"
+            return ["Picture-in-Picture"]
         case .arc, .dia:
-            return nil
+            return []
         }
     }
 

--- a/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
+++ b/FlashSpace/Features/PictureInPicture/Models/PipBrowser.swift
@@ -24,12 +24,13 @@ enum PipBrowser: String, CaseIterable {
 
     var titles: [String] {
         switch self {
-        case .chrome:
-            // Chrome has shipped both variants across versions.
-            return ["Picture-in-picture", "Picture in Picture"]
-        case .vivaldi, .brave, .opera, .comet, .edge:
-            return ["Picture in Picture"]
+        case .chrome, .vivaldi, .brave, .opera, .comet, .edge:
+            // Chromium-based browsers ship two variants of the PiP window title:
+            // "Picture in Picture" (macOS video-element PiP) and
+            // "Picture-in-picture" (document PiP, some sites/older builds).
+            return ["Picture in Picture", "Picture-in-picture"]
         case .zen, .firefox:
+            // Gecko-based browsers use a single hyphenated title.
             return ["Picture-in-Picture"]
         case .arc, .dia:
             return []


### PR DESCRIPTION
Resolves #589

Chrome on macOS has two distinct PiP code paths, each producing a
different window title:

- Video-element PiP (right-click video → Picture in Picture) uses a
  hard-coded macOS string `IDS_PICTURE_IN_PICTURE_TITLE_TEXT` =
  "Picture in Picture" (spaces, title case).
- Document PiP API (e.g. YouTube's miniplayer) inherits the page's
  `document.title`; YouTube sets it to "Picture-in-Picture"
  (hyphenated).

Which title appears depends on how PiP was triggered, not on Chrome
version or locale — so the existing exact match against
"Picture-in-picture" misses the video-element variant entirely.

Accept both literals so detection works regardless of entry point.