### PR TITLE
fix(hotkeys): preserve shortcuts on non-Latin layouts

### DIFF
--- a/FlashSpace/Features/HotKeys/Models/KeyCodesMap.swift
+++ b/FlashSpace/Features/HotKeys/Models/KeyCodesMap.swift
@@ -26,23 +26,21 @@ enum KeyCodesMap {
             for: TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeRetainedValue()
         )
 
-        keyCodes.merge(fallbackKeyCodes) { current, _ in current }
+        keyCodes.merge(fallbackKeyCodes) { _, fallback in fallback }
         return keyCodes
     }
 
     private static func createToString() -> [RawKeyCode: String] {
-        create(for: TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeRetainedValue())
+        var keyStrings = create(for: TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeRetainedValue())
             .reduce(into: [RawKeyCode: String]()) { result, pair in
-                result[pair.value] = pair.key
-
-                if pair.key == "+" {
-                    result[pair.value] = "plus"
-                }
-
-                for (alias, keyCode) in getAliases() {
-                    result[keyCode] = alias
-                }
+                result[pair.value] = pair.key == "+" ? "plus" : pair.key
             }
+
+        for (alias, keyCode) in getAliases() {
+            keyStrings[keyCode] = alias
+        }
+
+        return keyStrings
     }
 
     private static func create(for keyboard: TISInputSource) -> [String: RawKeyCode] {

--- a/FlashSpace/Features/HotKeys/Models/KeyCodesMap.swift
+++ b/FlashSpace/Features/HotKeys/Models/KeyCodesMap.swift
@@ -8,34 +8,49 @@
 import Carbon
 
 enum KeyCodesMap {
-    private(set) static var toKeyCode = create()
-
-    static let toString = toKeyCode.reduce(into: [RawKeyCode: String]()) { result, pair in
-        result[pair.value] = pair.key
-
-        if pair.key == "+" {
-            result[pair.value] = "plus"
-        }
-
-        for (alias, keyCode) in getAliases() {
-            result[keyCode] = alias
-        }
-    }
+    private(set) static var toKeyCode = createToKeyCode()
+    private(set) static var toString = createToString()
 
     static subscript(key: String) -> RawKeyCode? { toKeyCode[key] }
 
     static func refresh() {
-        toKeyCode = create()
+        toKeyCode = createToKeyCode()
+        toString = createToString()
     }
 
-    private static func create() -> [String: RawKeyCode] {
+    private static func createToKeyCode() -> [String: RawKeyCode] {
+        var keyCodes = create(
+            for: TISCopyCurrentKeyboardInputSource().takeRetainedValue()
+        )
+        let fallbackKeyCodes = create(
+            for: TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeRetainedValue()
+        )
+
+        keyCodes.merge(fallbackKeyCodes) { current, _ in current }
+        return keyCodes
+    }
+
+    private static func createToString() -> [RawKeyCode: String] {
+        create(for: TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeRetainedValue())
+            .reduce(into: [RawKeyCode: String]()) { result, pair in
+                result[pair.value] = pair.key
+
+                if pair.key == "+" {
+                    result[pair.value] = "plus"
+                }
+
+                for (alias, keyCode) in getAliases() {
+                    result[keyCode] = alias
+                }
+            }
+    }
+
+    private static func create(for keyboard: TISInputSource) -> [String: RawKeyCode] {
         var stringToKeyCodes: [String: RawKeyCode] = [:]
-        var currentKeyboard = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
-        var rawLayoutData = TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData)
-        if rawLayoutData == nil {
-            currentKeyboard = TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeUnretainedValue()
-            rawLayoutData = TISGetInputSourceProperty(currentKeyboard, kTISPropertyUnicodeKeyLayoutData)
-        }
+        guard let rawLayoutData = TISGetInputSourceProperty(
+            keyboard,
+            kTISPropertyUnicodeKeyLayoutData
+        ) else { return getAliases() }
 
         let layoutData = unsafeBitCast(rawLayoutData, to: CFData.self)
         let layout: UnsafePointer<UCKeyboardLayout> = unsafeBitCast(


### PR DESCRIPTION
Fixes the root cause behind #467 (same symptom in #261, likely also #477).

Saved shortcuts use characters such as `q`, but non-Latin layouts (e.g. Russian) cannot produce those characters, so `KeyCodesMap` has no entry for them and the shortcut is silently skipped during re-registration. The #201 notification (and the Input Monitoring workaround) covers the other half of the problem: it brings the shortcuts back once a Latin layout is active again. While a non-Latin layout is active, though, the rebuilt map simply has no `q` to register. And when the notification is *not* delivered, the stale registration keeps working by accident, which is why the symptom looks intermittent.

The fix keeps the active layout as the primary mapping, preserving the character-based behavior from #201, and only fills in characters the active layout is missing from the current ASCII-capable layout. Registration is unchanged for ASCII layouts (US ↔ Colemak etc.), because there the ASCII-capable layout *is* the active one. The reverse map used when recording is now built from the ASCII-capable layout and rebuilt on every layout change (previously it was computed once and never refreshed), so a shortcut recorded under a non-Latin layout serializes consistently (`opt+q`, not `opt+й`), and one recorded after switching e.g. US → Colemak uses the current layout's characters. Entries already saved with a non-Latin character are left as-is.

No new permissions, no event monitors, no config format changes: for users with a single Latin layout this is a no-op. The restructured `create(for:)` also checks for missing layout data before `unsafeBitCast` and fixes a small `TISInputSource` leak in the fallback path.

Verified manually on macOS 26.6.2 with ABC + Russian input sources: `opt+q` / `opt+w` keep working after switching English → Russian (previously they silently disappeared), digits keep working, and recording a shortcut while Russian is active serializes to the Latin character.

---

Full disclosure: this change was prepared with the help of AI coding agents (hence the `codex/*` branch prefix), but not blindly. I reviewed the diagnosis and the diff myself and checked them against the related history (#145, #193/#201, #544, #558 and [KeyboardShortcuts#236](https://github.com/sindresorhus/KeyboardShortcuts/pull/236)) specifically to keep the fix inside the existing character-based design rather than re-litigating it. Happy to adjust anything.